### PR TITLE
fix: handle empty wisdom response in Overview page

### DIFF
--- a/frontend/src/pages/Overview.tsx
+++ b/frontend/src/pages/Overview.tsx
@@ -22,7 +22,10 @@ export function Overview() {
         reflect()
       ]);
       setStats(statsData);
-      setWisdom(wisdomData);
+      // Only set wisdom if it has content (not an error response)
+      if (wisdomData && 'content' in wisdomData) {
+        setWisdom(wisdomData);
+      }
     } catch (e) {
       console.error('Failed to load stats:', e);
     } finally {
@@ -32,7 +35,10 @@ export function Overview() {
 
   async function refreshWisdom() {
     const data = await reflect();
-    setWisdom(data);
+    // Only set wisdom if it has content (not an error response)
+    if (data && 'content' in data) {
+      setWisdom(data);
+    }
   }
 
   if (loading) {


### PR DESCRIPTION
## Summary
- Fix crash when `/api/reflect` returns error response instead of Document
- Happens on fresh installs before any documents are indexed

## Problem
```
Uncaught TypeError: Cannot read properties of undefined (reading 'length')
```

When there are no documents, `/api/reflect` returns:
```json
{"error":"No documents found"}
```

But Overview.tsx expected a Document with `.content` property.

## Solution
Check that response has `content` property before setting wisdom state:
```typescript
if (wisdomData && 'content' in wisdomData) {
  setWisdom(wisdomData);
}
```

## Test Plan
- [x] Fresh install with no documents - page loads without crash
- [x] Shows stats grid and quick actions even without wisdom
- [x] Build passes

---
Related to #1 (Installation Guide Improvements)