### PR TITLE
feat: make Graph2D the default landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,8 +23,8 @@ function App() {
         <Route path="/doc/:id" element={<DocDetail />} />
         <Route path="/search" element={<Search />} />
         <Route path="/consult" element={<Consult />} />
-        <Route path="/graph" element={<Graph3D />} />
-        <Route path="/graph2d" element={<Graph />} />
+        <Route path="/graph" element={<Graph />} />
+        <Route path="/graph3d" element={<Graph3D />} />
         <Route path="/handoff" element={<Handoff />} />
         <Route path="/activity" element={<Activity />} />
         <Route path="/forum" element={<Forum />} />


### PR DESCRIPTION
## Summary

- Change `/graph` from Graph3D to Graph2D as default
- Add `/graph3d` route for 3D visualization
- Landing page stays as Overview

## Changes

| Route | Before | After |
|-------|--------|-------|
| `/` | Overview | Overview (unchanged) |
| `/graph` | Graph3D | **Graph2D** |
| `/graph3d` | - | Graph3D |

## Rationale

2D graph loads faster and is more accessible. Users who want 3D can go to `/graph3d`.

## Test Plan

- [x] `/` still shows Overview
- [x] `/graph` shows Graph2D
- [x] `/graph3d` shows Graph3D
- [x] Build passes

---

Requested by @pookiepew (Nat)