### PR TITLE
fix: speed up graph animation reveal (5s → 1.5s)

### DIFF
--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -163,7 +163,7 @@ export function Graph() {
 
     let time = 0;
     let revealProgress = 0; // 0 to 1, controls how many links are visible
-    const revealDuration = 5; // seconds to fully reveal all links
+    const revealDuration = 1.5; // seconds to fully reveal all links (faster start)
 
     function simulate() {
       time += 0.02;


### PR DESCRIPTION
## Summary
Animation reveal was too slow (5 seconds). Reduced to 1.5 seconds for snappier feel.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>