### PR TITLE
feat: add supersede_log and activity_log to Drizzle schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,8 @@ Closes #[issue-number]
 -   **Trying to implement everything at once** - Start with minimum viable implementation, test, then expand
 -   **Skipping AI Diary and Honest Feedback in retrospectives** - These sections provide crucial context and self-reflection that technical documentation alone cannot capture
 -   **Inline SQL for new tables** - Use Drizzle schema (`src/db/schema.ts`) + `bun db:push` instead of `db.exec(CREATE TABLE...)` in code
+-   **Modifying database outside Drizzle** - NEVER use direct SQL to ALTER TABLE, CREATE INDEX, or modify schema. Always update `src/db/schema.ts` first, then run `bun db:push`. If db:push finds schema drift (columns/indexes exist in DB but not in schema), add them to schema.ts to preserve data.
+-   **Drizzle db:push index bug** - Drizzle doesn't use `IF NOT EXISTS` for indexes. If indexes already exist (schema drift), db:push fails. Workaround: manually run `CREATE INDEX IF NOT EXISTS` or drop indexes first. Always backup before migrations!
 -   **Committing directly to main** - Always use GitHub flow: create feature branch → push → PR → wait for review/merge approval
 
 ### Useful Tricks Discovered

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -24,6 +24,8 @@ export default defineConfig({
     'forum_threads',
     'forum_messages',
     'decisions',
-    'trace_log',  // Issue #17
+    'trace_log',      // Issue #17
+    'supersede_log',  // Issue #18
+    'activity_log',   // User activity tracking
   ],
 });


### PR DESCRIPTION
## Summary

- Add `supersede_log` table for audit trail tracking ("Nothing is Deleted" philosophy)
- Add `activity_log` table for user activity tracking
- Add `repoRoot` column to `indexingStatus` (preserves existing data)
- Document Drizzle `db:push` index bug workaround in CLAUDE.md

## Background

Tables already existed in database (created via direct SQL in previous sessions). This PR syncs the Drizzle schema to match the actual database state.

## Lessons Learned

1. **Never modify database outside Drizzle** - Always update `src/db/schema.ts` first
2. **Drizzle db:push doesn't use IF NOT EXISTS for indexes** - Manual sync needed when schema drifts
3. **Backup before migrations** - Essential when reconciling schema drift

## Test Plan

- [x] Verified tables exist with correct structure
- [x] Verified all indexes created
- [x] Database backup created before changes

Refs #18

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)