### PR TITLE
Add distance and model fields to search results

### DIFF
--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -137,6 +137,7 @@ export async function handleSearch(
         const projectMap = new Map<string, string | null>();
         rows.forEach(r => projectMap.set(r.id, r.project));
 
+        const resolvedModelName = (model && EMBEDDING_MODELS[model]) ? model : 'nomic';
         vectorResults = chromaResults.ids
           .map((id: string, i: number) => {
             // Cosine distance: 0=identical, 1=orthogonal, 2=opposite
@@ -152,7 +153,9 @@ export async function handleSearch(
               concepts: [],
               project: docProject,
               source: 'vector' as const,
-              score: similarity
+              score: similarity,
+              distance,
+              model: resolvedModelName
             };
           })
           // Filter by project: match FTS behavior
@@ -235,7 +238,9 @@ function combineSearchResults(fts: SearchResult[], vector: SearchResult[]): Sear
       seen.set(r.id, {
         ...existing,
         score: Math.min(1, maxScore + bonus), // Cap at 1.0
-        source: 'hybrid' as const
+        source: 'hybrid' as const,
+        distance: r.distance,
+        model: r.model
       });
     } else {
       seen.set(r.id, r);

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -10,6 +10,8 @@ export interface SearchResult {
   concepts: string[];
   source?: 'fts' | 'vector' | 'hybrid';
   score?: number;
+  distance?: number;
+  model?: string;
 }
 
 export interface SearchResponse {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -127,6 +127,8 @@ export async function vectorSearch(
   source_file: string;
   concepts: string[];
   score: number;
+  distance: number;
+  model: string;
   source: 'vector';
 }>> {
   try {
@@ -141,6 +143,7 @@ export async function vectorSearch(
       return [];
     }
 
+    const resolvedModelName = model || 'nomic';
     const mappedResults: Array<{
       id: string;
       type: string;
@@ -148,19 +151,24 @@ export async function vectorSearch(
       source_file: string;
       concepts: string[];
       score: number;
+      distance: number;
+      model: string;
       source: 'vector';
     }> = [];
 
     for (let i = 0; i < results.ids.length; i++) {
       const metadata = results.metadatas[i] as Record<string, unknown> | null;
 
+      const rawDistance = results.distances[i] || 0;
       mappedResults.push({
         id: results.ids[i],
         type: (metadata?.type as string) || 'unknown',
         content: (results.documents[i] || '').substring(0, 500),
         source_file: (metadata?.source_file as string) || '',
         concepts: parseConceptsFromMetadata(metadata?.concepts),
-        score: results.distances[i] || 0,
+        score: rawDistance,
+        distance: rawDistance,
+        model: resolvedModelName,
         source: 'vector',
       });
     }
@@ -194,6 +202,8 @@ export function combineResults(
     source_file: string;
     concepts: string[];
     score: number;
+    distance: number;
+    model: string;
     source: 'vector';
   }>,
   ftsWeight: number = 0.5,
@@ -208,6 +218,8 @@ export function combineResults(
   source: 'fts' | 'vector' | 'hybrid';
   ftsScore?: number;
   vectorScore?: number;
+  distance?: number;
+  model?: string;
 }> {
   const resultMap = new Map<string, {
     id: string;
@@ -217,6 +229,8 @@ export function combineResults(
     concepts: string[];
     ftsScore?: number;
     vectorScore?: number;
+    distance?: number;
+    model?: string;
     source: 'fts' | 'vector' | 'hybrid';
   }>();
 
@@ -239,6 +253,8 @@ export function combineResults(
     if (existing) {
       existing.vectorScore = result.score;
       existing.source = 'hybrid';
+      existing.distance = result.distance;
+      existing.model = result.model;
     } else {
       resultMap.set(result.id, {
         id: result.id,
@@ -247,6 +263,8 @@ export function combineResults(
         source_file: result.source_file,
         concepts: result.concepts,
         vectorScore: result.score,
+        distance: result.distance,
+        model: result.model,
         source: 'vector',
       });
     }
@@ -276,6 +294,8 @@ export function combineResults(
       source: result.source,
       ftsScore: result.ftsScore,
       vectorScore: result.vectorScore,
+      distance: result.distance,
+      model: result.model,
     };
   });
 


### PR DESCRIPTION
## Summary
- Add `distance` (raw vector distance) and `model` (embedding model name) fields to `SearchResult` type
- Include these fields in HTTP handler (`src/server/handlers.ts`) vector results and hybrid merge
- Include these fields in MCP handler (`src/tools/search.ts`) vector results and combined results
- Replaces #331 which conflicted after #330 was squash-merged

## Test plan
- [x] All 203 tests pass (`bun test`)
- [ ] Verify search responses include `distance` and `model` for vector/hybrid results
- [ ] Verify FTS-only results have `distance: undefined` and `model: undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)