### PR TITLE
Add /api/plugins endpoints for WASM

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -543,6 +543,32 @@ app.get('/api/feed', (c) => {
   }
 });
 
+// WASM Plugins (served from ~/.oracle/plugins/)
+const PLUGINS_DIR = path.join(process.env.HOME || '/home/nat', '.oracle', 'plugins');
+
+app.get('/api/plugins', (c) => {
+  try {
+    if (!fs.existsSync(PLUGINS_DIR)) return c.json({ plugins: [] });
+    const files = fs.readdirSync(PLUGINS_DIR).filter(f => f.endsWith('.wasm'));
+    const plugins = files.map(f => {
+      const stat = fs.statSync(path.join(PLUGINS_DIR, f));
+      return { name: f.replace('.wasm', ''), file: f, size: stat.size, modified: stat.mtime.toISOString() };
+    });
+    return c.json({ plugins });
+  } catch (e: any) {
+    return c.json({ plugins: [], error: e.message });
+  }
+});
+
+app.get('/api/plugins/:name', (c) => {
+  const name = c.req.param('name');
+  const file = name.endsWith('.wasm') ? name : `${name}.wasm`;
+  const filePath = path.join(PLUGINS_DIR, file);
+  if (!fs.existsSync(filePath)) return c.json({ error: 'Plugin not found' }, 404);
+  const buf = fs.readFileSync(filePath);
+  return new Response(buf, { headers: { 'Content-Type': 'application/wasm' } });
+});
+
 // Logs
 app.get('/api/logs', (c) => {
   try {


### PR DESCRIPTION
## Summary
- `GET /api/plugins` — list .wasm files from `~/.oracle/plugins/`
- `GET /api/plugins/:name` — serve .wasm binary with correct Content-Type

Used by oracle-studio Plugins page to load and execute WASM plugins in browser.

## Test plan
- [ ] Verify `/api/plugins` returns list of available plugins
- [ ] Verify `/api/plugins/demo` serves demo.wasm binary
- [ ] Confirm oracle-studio Plugins page loads and executes WASM

🤖 Generated with [Claude Code](https://claude.com/claude-code)