### PR TITLE
feat: configurable tool groups v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle",
-  "version": "0.4.0-nightly",
+  "version": "0.5.0",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'bun:test';
+import { TOOL_GROUPS, getDisabledTools, loadToolGroupConfig, type ToolGroupConfig } from '../tool-groups.ts';
+
+describe('tool-groups', () => {
+  it('defines 6 groups with correct tool counts', () => {
+    expect(Object.keys(TOOL_GROUPS)).toHaveLength(6);
+    expect(TOOL_GROUPS.search).toHaveLength(4);
+    expect(TOOL_GROUPS.knowledge).toHaveLength(5);
+    expect(TOOL_GROUPS.session).toHaveLength(2);
+    expect(TOOL_GROUPS.schedule).toHaveLength(2);
+    expect(TOOL_GROUPS.forum).toHaveLength(4);
+    expect(TOOL_GROUPS.trace).toHaveLength(6);
+  });
+
+  it('returns empty set when all groups enabled', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      schedule: true, forum: true, trace: true,
+    };
+    expect(getDisabledTools(config).size).toBe(0);
+  });
+
+  it('disables correct tools when groups are off', () => {
+    const config: ToolGroupConfig = {
+      search: true, knowledge: true, session: true,
+      schedule: false, forum: true, trace: false,
+    };
+    const disabled = getDisabledTools(config);
+    expect(disabled.has('oracle_schedule_add')).toBe(true);
+    expect(disabled.has('oracle_schedule_list')).toBe(true);
+    expect(disabled.has('oracle_trace')).toBe(true);
+    expect(disabled.has('oracle_trace_list')).toBe(true);
+    expect(disabled.has('oracle_search')).toBe(false);
+    expect(disabled.has('oracle_learn')).toBe(false);
+  });
+
+  it('defaults to all groups enabled', () => {
+    const config = loadToolGroupConfig('/nonexistent/path');
+    expect(config.search).toBe(true);
+    expect(config.knowledge).toBe(true);
+    expect(config.session).toBe(true);
+    expect(config.schedule).toBe(true);
+    expect(config.forum).toBe(true);
+    expect(config.trace).toBe(true);
+  });
+
+  it('all tool names follow oracle_ prefix convention', () => {
+    for (const tools of Object.values(TOOL_GROUPS)) {
+      for (const tool of tools) {
+        expect(tool).toMatch(/^oracle_/);
+      }
+    }
+  });
+});

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -1,0 +1,78 @@
+/**
+ * Tool Group Configuration
+ *
+ * Controls which tool groups are registered at startup.
+ * Config sources (in priority order):
+ *   1. arra.config.json in repo root (ORACLE_REPO_ROOT or cwd)
+ *   2. ~/.oracle/config.json (global)
+ *   3. Defaults: all groups enabled
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export const TOOL_GROUPS = {
+  search: ['oracle_search', 'oracle_read', 'oracle_list', 'oracle_concepts'],
+  knowledge: ['oracle_learn', 'oracle_reflect', 'oracle_stats', 'oracle_supersede', 'oracle_verify'],
+  session: ['oracle_handoff', 'oracle_inbox'],
+  schedule: ['oracle_schedule_add', 'oracle_schedule_list'],
+  forum: ['oracle_thread', 'oracle_threads', 'oracle_thread_read', 'oracle_thread_update'],
+  trace: ['oracle_trace', 'oracle_trace_list', 'oracle_trace_get', 'oracle_trace_link', 'oracle_trace_unlink', 'oracle_trace_chain'],
+} as const;
+
+export type ToolGroupName = keyof typeof TOOL_GROUPS;
+
+export type ToolGroupConfig = Record<ToolGroupName, boolean>;
+
+const DEFAULT_CONFIG: ToolGroupConfig = {
+  search: true,
+  knowledge: true,
+  session: true,
+  schedule: true,
+  forum: true,
+  trace: true,
+};
+
+function readJsonSafe(filePath: string): Record<string, any> | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
+  const root = repoRoot || process.env.ORACLE_REPO_ROOT || process.cwd();
+  const homeDir = process.env.HOME || process.env.USERPROFILE || '/tmp';
+
+  // Priority 1: repo-local arra.config.json
+  const localConfig = readJsonSafe(path.join(root, 'arra.config.json'));
+  if (localConfig?.tools) {
+    console.error('[ToolGroups] Using arra.config.json from repo root');
+    return { ...DEFAULT_CONFIG, ...localConfig.tools };
+  }
+
+  // Priority 2: global ~/.oracle/config.json
+  const globalConfig = readJsonSafe(path.join(homeDir, '.oracle', 'config.json'));
+  if (globalConfig?.tools) {
+    console.error('[ToolGroups] Using ~/.oracle/config.json');
+    return { ...DEFAULT_CONFIG, ...globalConfig.tools };
+  }
+
+  // Priority 3: all enabled
+  return { ...DEFAULT_CONFIG };
+}
+
+/** Returns a Set of tool names that should be disabled based on config */
+export function getDisabledTools(config: ToolGroupConfig): Set<string> {
+  const disabled = new Set<string>();
+  for (const [group, tools] of Object.entries(TOOL_GROUPS)) {
+    if (!config[group as ToolGroupName]) {
+      for (const tool of tools) {
+        disabled.add(tool);
+      }
+    }
+  }
+  return disabled;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { createVectorStore } from './vector/factory.ts';
 import type { VectorStoreAdapter } from './vector/types.ts';
 import path from 'path';
 import fs from 'fs';
+import { loadToolGroupConfig, getDisabledTools, type ToolGroupConfig } from './config/tool-groups.ts';
 
 // Tool handlers (all extracted to src/tools/)
 import type { ToolContext } from './tools/types.ts';
@@ -88,13 +89,21 @@ class OracleMCPServer {
   private vectorStatus: 'unknown' | 'connected' | 'unavailable' = 'unknown';
   private readOnly: boolean;
   private version: string;
+  private disabledTools: Set<string>;
 
-  constructor(options: { readOnly?: boolean } = {}) {
+  constructor(options: { readOnly?: boolean; toolGroups?: ToolGroupConfig } = {}) {
     this.readOnly = options.readOnly ?? false;
     if (this.readOnly) {
       console.error('[Oracle] Running in READ-ONLY mode');
     }
     this.repoRoot = process.env.ORACLE_REPO_ROOT || process.cwd();
+
+    const groupConfig = options.toolGroups ?? loadToolGroupConfig(this.repoRoot);
+    this.disabledTools = getDisabledTools(groupConfig);
+    const disabledGroups = Object.entries(groupConfig).filter(([, v]) => !v).map(([k]) => k);
+    if (disabledGroups.length > 0) {
+      console.error(`[ToolGroups] Disabled: ${disabledGroups.join(', ')}`);
+    }
 
     const homeDir = process.env.HOME || process.env.USERPROFILE || '/tmp';
 
@@ -197,9 +206,10 @@ class OracleMCPServer {
         scheduleListToolDef,
       ];
 
-      const tools = this.readOnly
-        ? allTools.filter(t => !WRITE_TOOLS.includes(t.name))
-        : allTools;
+      let tools = allTools.filter(t => !this.disabledTools.has(t.name));
+      if (this.readOnly) {
+        tools = tools.filter(t => !WRITE_TOOLS.includes(t.name));
+      }
 
       return { tools };
     });
@@ -208,6 +218,16 @@ class OracleMCPServer {
     // Handle tool calls — route to extracted handlers
     // ================================================================
     this.server.setRequestHandler(CallToolRequestSchema, async (request): Promise<any> => {
+      if (this.disabledTools.has(request.params.name)) {
+        return {
+          content: [{
+            type: 'text',
+            text: `Error: Tool "${request.params.name}" is disabled by tool group config. Check ~/.oracle/config.json or arra.config.json.`
+          }],
+          isError: true
+        };
+      }
+
       if (this.readOnly && WRITE_TOOLS.includes(request.params.name)) {
         return {
           content: [{


### PR DESCRIPTION
## Summary
- Add 6 tool groups (search/4, knowledge/5, session/2, schedule/2, forum/4, trace/6) that can be toggled on/off
- Config priority: `arra.config.json` (repo root) > `~/.oracle/config.json` > defaults (all enabled)
- Disabled tools are filtered from ListTools and rejected in CallTool
- Backward compatible: all groups enabled by default

## Config format
```json
{ "tools": { "search": true, "knowledge": true, "session": true, "schedule": false, "forum": true, "trace": false } }
```

## Test plan
- [x] 5 unit tests pass for tool-groups module
- [x] All 145 existing unit tests still pass
- [x] Default config returns all groups enabled
- [x] Disabled groups correctly exclude their tools

Closes #503

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>