### PR TITLE
rebrand: arra-oracle → arra-oracle-v3 + oracle_ → arra_ tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ TypeScript MCP server for semantic search over Oracle philosophy — SQLite FTS5
 ## Architecture
 
 ```
-arra-oracle (one package, two bins)
-├── bunx arra-oracle                          → MCP server (src/index.ts)
-├── bunx --package arra-oracle oracle-vault   → Vault CLI (src/vault/cli.ts)
+arra-oracle-v3 (one package, two bins)
+├── bunx arra-oracle-v3                          → MCP server (src/index.ts)
+├── bunx --package arra-oracle-v3 oracle-vault   → Vault CLI (src/vault/cli.ts)
 ├── bun run server                          → HTTP API (src/server.ts)
 └── bun run index                           → Indexer (src/indexer.ts)
 
@@ -40,25 +40,25 @@ Distributed via GitHub — no npm publish needed:
 
 ```bash
 # MCP server (stdio, for Claude Code)
-bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle#main
+bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3#main
 
 # Vault CLI (secondary bin — use --package)
-bunx --bun --package arra-oracle@github:Soul-Brews-Studio/arra-oracle#main oracle-vault --help
+bunx --bun --package arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3#main oracle-vault --help
 ```
 
 ### Add to Claude Code
 
 ```bash
-claude mcp add arra-oracle -- bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle#main
+claude mcp add arra-oracle-v3 -- bunx --bun arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3#main
 ```
 
 Or in `~/.claude.json`:
 ```json
 {
   "mcpServers": {
-    "arra-oracle": {
+    "arra-oracle-v3": {
       "command": "bunx",
-      "args": ["--bun", "arra-oracle@github:Soul-Brews-Studio/arra-oracle#main"]
+      "args": ["--bun", "arra-oracle-v3@github:Soul-Brews-Studio/arra-oracle-v3#main"]
     }
   }
 }
@@ -67,8 +67,8 @@ Or in `~/.claude.json`:
 ### From source
 
 ```bash
-git clone https://github.com/Soul-Brews-Studio/arra-oracle.git
-cd arra-oracle && bun install
+git clone https://github.com/Soul-Brews-Studio/arra-oracle-v3.git
+cd arra-oracle-v3 && bun install
 bun run dev          # MCP server
 bun run server       # HTTP API on :47778
 ```
@@ -77,7 +77,7 @@ bun run server       # HTTP API on :47778
 <summary>Install script (legacy)</summary>
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle/main/scripts/install.sh | bash
+curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle-v3/main/scripts/install.sh | bash
 ```
 </details>
 
@@ -165,7 +165,7 @@ bun db:studio     # Open Drizzle Studio GUI
 ## Project Structure
 
 ```
-arra-oracle/
+arra-oracle-v3/
 ├── src/
 │   ├── index.ts          # MCP server entry
 │   ├── server.ts         # HTTP API (Hono)

--- a/docs/API.md
+++ b/docs/API.md
@@ -60,7 +60,7 @@ Returns server status.
 ```json
 {
   "status": "ok",
-  "server": "oracle-v2",
+  "server": "arra-oracle-v3",
   "port": 47778
 }
 ```
@@ -479,7 +479,7 @@ bun run server &                  # Backend on :47778
 cd frontend && bun dev &          # Frontend on :3000
 
 # 3. Run E2E tests
-cd ~/.claude/skills/dev-browser && npx tsx /path/to/oracle-v2/e2e/run-e2e.ts
+cd ~/.claude/skills/dev-browser && npx tsx /path/to/arra-oracle-v3/e2e/run-e2e.ts
 ```
 
 **E2E Test Coverage (14 tests):**

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -5,11 +5,11 @@ Complete guide for fresh installation with seed data.
 ## Quick Install (Recommended)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle/main/scripts/fresh-install.sh | bash
+curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle-v3/main/scripts/fresh-install.sh | bash
 ```
 
 This one-liner will:
-1. Clone to `~/.local/share/arra-oracle`
+1. Clone to `~/.local/share/arra-oracle-v3`
 2. Install dependencies
 3. Create seed philosophy files
 4. Index seed data (29 documents)
@@ -19,7 +19,7 @@ This one-liner will:
 
 ### Installation Directory
 ```
-~/.local/share/arra-oracle/    # Code
+~/.local/share/arra-oracle-v3/    # Code
 ~/.oracle/                 # Data
 ├── oracle.db                 # SQLite database
 └── seed/                     # Seed philosophy files
@@ -50,7 +50,7 @@ This one-liner will:
 
 ### 1. Start Server
 ```bash
-cd ~/.local/share/arra-oracle
+cd ~/.local/share/arra-oracle-v3
 bun run server
 ```
 
@@ -74,9 +74,9 @@ Add to `~/.claude.json`:
 ```json
 {
   "mcpServers": {
-    "arra-oracle": {
+    "arra-oracle-v3": {
       "command": "bun",
-      "args": ["run", "~/.local/share/arra-oracle/src/index.ts"]
+      "args": ["run", "~/.local/share/arra-oracle-v3/src/index.ts"]
     }
   }
 }
@@ -88,8 +88,8 @@ If you prefer step-by-step:
 
 ```bash
 # 1. Clone
-git clone https://github.com/Soul-Brews-Studio/arra-oracle.git ~/.local/share/arra-oracle
-cd ~/.local/share/arra-oracle
+git clone https://github.com/Soul-Brews-Studio/arra-oracle-v3.git ~/.local/share/arra-oracle-v3
+cd ~/.local/share/arra-oracle-v3
 
 # 2. Install dependencies
 bun install
@@ -165,7 +165,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ## Uninstall
 
 ```bash
-rm -rf ~/.local/share/arra-oracle
+rm -rf ~/.local/share/arra-oracle-v3
 rm -rf ~/.oracle
 ```
 

--- a/docs/REBRAND-RUNBOOK.md
+++ b/docs/REBRAND-RUNBOOK.md
@@ -1,16 +1,16 @@
-# Rebrand Runbook: oracle-v2 → arra-oracle
+# Rebrand Runbook: arra-oracle-v3 → arra-oracle-v3
 
 > วันที่สร้าง: 2026-03-16
 > สถานะ: พร้อม execute
 
 ## Pre-flight Checklist
 
-- [x] PR #423 (oracle-v2 source) — tests pass, code review done
+- [x] PR #423 (arra-oracle-v3 source) — tests pass, code review done
 - [x] PR #71 (oracle-skills-cli) — 110 tests pass
 - [x] PR #1 (oracle-cli), #2 (oracle-studio) — ready
 - [x] PR #4 (mother-oracle registry) — ready
 - [x] Fleet CLAUDE.md PRs (8 repos) — ready
-- [x] `~/.claude.json` MCP key already renamed to `arra-oracle`
+- [x] `~/.claude.json` MCP key already renamed to `arra-oracle-v3`
 - [x] `~/.claude.json` backup at `~/.claude.json.bak-before-rebrand`
 
 ---
@@ -21,33 +21,33 @@
 
 ```bash
 # 1. Merge PR หลัก
-gh pr merge 423 --repo Soul-Brews-Studio/oracle-v2 --merge
+gh pr merge 423 --repo Soul-Brews-Studio/arra-oracle-v3 --merge
 
 # 2. Rename repo (ATOMIC — GitHub auto-redirect ทันที)
-gh repo rename arra-oracle --repo Soul-Brews-Studio/oracle-v2
+gh repo rename arra-oracle-v3 --repo Soul-Brews-Studio/arra-oracle-v3
 
 # 3. Verify redirect works
-gh repo view Soul-Brews-Studio/arra-oracle --json name
-# Expected: { "name": "arra-oracle" }
+gh repo view Soul-Brews-Studio/arra-oracle-v3 --json name
+# Expected: { "name": "arra-oracle-v3" }
 ```
 
 ### Phase 2: Update Local (5 นาที)
 
 ```bash
 # 4. Re-clone to new ghq path
-ghq get -u -p Soul-Brews-Studio/arra-oracle
+ghq get -u -p Soul-Brews-Studio/arra-oracle-v3
 
 # 5. Update ~/.claude.json paths (ใช้ jq)
 jq '
-  .mcpServers["arra-oracle"].args = [
-    "/home/nat/Code/github.com/Soul-Brews-Studio/arra-oracle/src/index.ts"
+  .mcpServers["arra-oracle-v3"].args = [
+    "/home/nat/Code/github.com/Soul-Brews-Studio/arra-oracle-v3/src/index.ts"
   ] |
-  .mcpServers["arra-oracle"].env.ORACLE_REPO_ROOT =
-    "/home/nat/Code/github.com/Soul-Brews-Studio/arra-oracle"
+  .mcpServers["arra-oracle-v3"].env.ORACLE_REPO_ROOT =
+    "/home/nat/Code/github.com/Soul-Brews-Studio/arra-oracle-v3"
 ' ~/.claude.json > /tmp/claude-json-tmp && mv /tmp/claude-json-tmp ~/.claude.json
 
 # 6. Verify MCP config
-jq '.mcpServers["arra-oracle"]' ~/.claude.json
+jq '.mcpServers["arra-oracle-v3"]' ~/.claude.json
 ```
 
 ### Phase 3: Merge Fleet (10 นาที)
@@ -80,14 +80,14 @@ gh pr merge 2 --repo Soul-Brews-Studio/clawdacle --merge
 
 ```bash
 # 12. Old URL redirects?
-curl -sI https://github.com/Soul-Brews-Studio/oracle-v2 | head -3
-# Expected: 301 → arra-oracle
+curl -sI https://github.com/Soul-Brews-Studio/arra-oracle-v3 | head -3
+# Expected: 301 → arra-oracle-v3
 
 # 13. Registry sync works?
 cd ~/Code/github.com/laris-co/mother-oracle && bun registry/sync.ts
 
 # 14. MCP server starts?
-# (restart Claude Code session — new MCP prefix mcp__arra-oracle__*)
+# (restart Claude Code session — new MCP prefix mcp__arra-oracle-v3__*)
 
 # 15. Skills work?
 # /oracle-family-scan --stats
@@ -99,7 +99,7 @@ cd ~/Code/github.com/laris-co/mother-oracle && bun registry/sync.ts
 
 ```bash
 # Rename back
-gh repo rename oracle-v2 --repo Soul-Brews-Studio/arra-oracle
+gh repo rename arra-oracle-v3 --repo Soul-Brews-Studio/arra-oracle-v3
 
 # Revert ~/.claude.json
 cp ~/.claude.json.bak-before-rebrand ~/.claude.json
@@ -114,10 +114,10 @@ git checkout main -- registry/config.json registry/sync.ts
 ## Post-Rebrand (ทำทีหลังได้)
 
 - [ ] Regenerate `skills-vfs.ts` in oracle-skills-cli
-- [ ] `maw hey` fleet notification — "oracle-v2 is now arra-oracle"
+- [ ] `maw hey` fleet notification — "arra-oracle-v3 is now arra-oracle-v3"
 - [ ] Update buildwithoracle.com blog posts (Calliope)
-- [ ] npm publish under new name `arra-oracle`
-- [ ] Clean up old ghq path: `rm -rf ~/Code/github.com/Soul-Brews-Studio/oracle-v2`
+- [ ] npm publish under new name `arra-oracle-v3`
+- [ ] Clean up old ghq path: `rm -rf ~/Code/github.com/Soul-Brews-Studio/arra-oracle-v3`
 
 ---
 
@@ -125,9 +125,9 @@ git checkout main -- registry/config.json registry/sync.ts
 
 | What | Before | After |
 |------|--------|-------|
-| Repo | Soul-Brews-Studio/oracle-v2 | Soul-Brews-Studio/arra-oracle |
-| npm | oracle-v2 | arra-oracle |
-| MCP prefix | mcp__oracle-v2__* | mcp__arra-oracle__* |
-| bin | `bunx oracle-v2` | `bunx arra-oracle` |
+| Repo | Soul-Brews-Studio/arra-oracle-v3 | Soul-Brews-Studio/arra-oracle-v3 |
+| npm | arra-oracle-v3 | arra-oracle-v3 |
+| MCP prefix | mcp__arra-oracle-v3__* | mcp__arra-oracle-v3__* |
+| bin | `bunx arra-oracle-v3` | `bunx arra-oracle-v3` |
 | Data dir | `~/.oracle/` | `~/.oracle/` (unchanged) |
 | DB path | `~/.oracle/oracle.db` | `~/.oracle/oracle.db` (unchanged) |

--- a/docs/SPEC-original.md
+++ b/docs/SPEC-original.md
@@ -1,5 +1,5 @@
 ---
-title: Oracle v2 - MCP Memory Layer (Original Specification)
+title: Arra Oracle v3 - MCP Memory Layer (Original Specification)
 created: 2025-12-29
 archived: 2026-01-15
 status: historical
@@ -7,7 +7,7 @@ learned-from: claude-mem
 note: This is the original planning document with implementation annotations.
 ---
 
-# Oracle v2 - Original Specification (Dec 2025)
+# Arra Oracle v3 - Original Specification (Dec 2025)
 
 > **📜 Historical Document**: Original planning spec from Dec 29, 2025.
 > Annotated with what was actually implemented by Jan 15, 2026.
@@ -24,7 +24,7 @@ note: This is the original planning document with implementation annotations.
 
 ## Vision ✅
 
-Oracle v2 transforms the existing Oracle philosophy files into a **searchable knowledge system** via MCP, allowing Claude to:
+Arra Oracle v3 transforms the existing Oracle philosophy files into a **searchable knowledge system** via MCP, allowing Claude to:
 
 1. ✅ **Consult** Oracle philosophy when making decisions
 2. ✅ **Learn** from patterns in resonance files
@@ -188,7 +188,7 @@ See [TIMELINE.md](../TIMELINE.md) for full history.
 
 ## Original Next Steps ✅ ALL DONE
 
-- [x] Create ψ/lab/oracle-v2/prototype.ts → Became `src/index.ts`
+- [x] Create ψ/lab/arra-oracle-v3/prototype.ts → Became `src/index.ts`
 - [x] Test Chroma indexing → Works with 5,500+ documents
 - [x] Create oracle skill → Evolved to 19 MCP tools
 - [x] Test in real session → Production since Jan 15

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,10 @@
-# Oracle v2 Architecture
+# Arra Oracle v3 Architecture
 
 > Knowledge system MCP server with hybrid search, consultation logging, and learning capabilities.
 
 ## Overview
 
-Oracle v2 indexes philosophy from markdown files and provides:
+Arra Oracle v3 indexes philosophy from markdown files and provides:
 - **Semantic + keyword search** (ChromaDB + FTS5)
 - **Decision guidance** via principles and patterns
 - **Learning capture** from sessions
@@ -182,9 +182,9 @@ CREATE TABLE indexing_status (
 ```json
 {
   "mcpServers": {
-    "oracle-v2": {
+    "arra-oracle-v3": {
       "command": "node",
-      "args": ["/path/to/oracle-v2/dist/index.js"],
+      "args": ["/path/to/arra-oracle-v3/dist/index.js"],
       "env": {
         "ORACLE_REPO_ROOT": "/path/to/knowledge-base"
       }

--- a/docs/issues/trace-log-feature-spec.md
+++ b/docs/issues/trace-log-feature-spec.md
@@ -145,7 +145,7 @@ CREATE INDEX idx_trace_created ON trace_log(created_at DESC);
 [
   {
     "number": 40,
-    "title": "Oracle v2 - Open Source Framework",
+    "title": "Arra Oracle v3 - Open Source Framework",
     "state": "open",
     "url": "https://github.com/laris-co/Nat-s-Agents/issues/40",
     "match_reason": "title match"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "arra-oracle",
+  "name": "arra-oracle-v3",
   "version": "0.5.0",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",
   "bin": {
-    "arra-oracle": "./src/index.ts"
+    "arra-oracle-v3": "./src/index.ts"
   },
   "files": [
     "src",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Soul-Brews-Studio/arra-oracle.git"
+    "url": "https://github.com/Soul-Brews-Studio/arra-oracle-v3.git"
   },
   "publishConfig": {
     "access": "public"

--- a/scripts/com.oracle.server.plist.example
+++ b/scripts/com.oracle.server.plist.example
@@ -10,7 +10,7 @@
         <string>/bin/bash</string>
         <string>-c</string>
         <!-- Replace $HOME and paths below with your actual paths -->
-        <string>pkill -f 'bun.*oracle-v2/src/server.ts' 2>/dev/null; sleep 1; exec $HOME/.bun/bin/bun $HOME/Code/github.com/laris-co/oracle-v2/src/server.ts</string>
+        <string>pkill -f 'bun.*arra-oracle-v3/src/server.ts' 2>/dev/null; sleep 1; exec $HOME/.bun/bin/bun $HOME/Code/github.com/laris-co/arra-oracle-v3/src/server.ts</string>
     </array>
 
     <!-- Set to true to auto-start at login -->
@@ -24,13 +24,13 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>$HOME/.oracle-v2/oracle-server.log</string>
+    <string>$HOME/.arra-oracle-v3/oracle-server.log</string>
 
     <key>StandardErrorPath</key>
-    <string>$HOME/.oracle-v2/oracle-server.error.log</string>
+    <string>$HOME/.arra-oracle-v3/oracle-server.error.log</string>
 
     <key>WorkingDirectory</key>
-    <string>$HOME/Code/github.com/laris-co/oracle-v2</string>
+    <string>$HOME/Code/github.com/laris-co/arra-oracle-v3</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/scripts/fresh-install.sh
+++ b/scripts/fresh-install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Fresh installation of Arra Oracle with seed data
-# Usage: curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle/main/scripts/fresh-install.sh | bash
+# Usage: curl -sSL https://raw.githubusercontent.com/Soul-Brews-Studio/arra-oracle-v3/main/scripts/fresh-install.sh | bash
 set -e
 
-INSTALL_DIR="${ORACLE_INSTALL_DIR:-$HOME/.local/share/arra-oracle}"
+INSTALL_DIR="${ORACLE_INSTALL_DIR:-$HOME/.local/share/arra-oracle-v3}"
 DATA_DIR="$HOME/.oracle"
 
 echo "🔮 Arra Oracle - Fresh Installation"
@@ -47,7 +47,7 @@ fi
 
 # Clone
 echo "📥 Cloning Arra Oracle..."
-git clone --depth 1 https://github.com/Soul-Brews-Studio/arra-oracle.git "$INSTALL_DIR"
+git clone --depth 1 https://github.com/Soul-Brews-Studio/arra-oracle-v3.git "$INSTALL_DIR"
 cd "$INSTALL_DIR"
 
 # Install dependencies
@@ -89,7 +89,7 @@ echo ""
 echo "📝 Add to Claude Code (~/.claude.json):"
 echo '  {'
 echo '    "mcpServers": {'
-echo '      "arra-oracle": {'
+echo '      "arra-oracle-v3": {'
 echo '        "command": "bun",'
 echo "        \"args\": [\"run\", \"$INSTALL_DIR/src/index.ts\"]"
 echo '      }'
@@ -116,4 +116,4 @@ elif command -v ifconfig &> /dev/null; then
     done
 fi
 echo ""
-echo "📖 Docs: https://github.com/Soul-Brews-Studio/arra-oracle"
+echo "📖 Docs: https://github.com/Soul-Brews-Studio/arra-oracle-v3"

--- a/scripts/generate-vault-report.mjs
+++ b/scripts/generate-vault-report.mjs
@@ -413,7 +413,7 @@ function generateHTML() {
     </div>` : ''}
 
     <footer class="text-center text-gray-600 text-[10px] py-3 border-t border-white/5">
-      <a href="https://github.com/Soul-Brews-Studio/oracle-v2" class="text-gray-500 hover:text-gray-300">oracle-v2</a> &middot; <span class="font-mono">${generated}</span>
+      <a href="https://github.com/Soul-Brews-Studio/arra-oracle-v3" class="text-gray-500 hover:text-gray-300">arra-oracle-v3</a> &middot; <span class="font-mono">${generated}</span>
     </footer>
   </div>
 </body>

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -45,7 +45,7 @@ if launchctl list | grep -q "com.oracle.server"; then
     echo "   Stop:    launchctl unload ~/Library/LaunchAgents/$PLIST_NAME"
     echo "   Start:   launchctl load ~/Library/LaunchAgents/$PLIST_NAME"
     echo "   Status:  launchctl list | grep oracle"
-    echo "   Logs:    tail -f ~/.oracle/oracle-server.log"
+    echo "   Logs:    tail -f ~/.arra-oracle-v3/oracle-server.log"
 else
     echo "⚠ Service may not have started. Check logs:"
     echo "   tail -f $LOG_DIR/oracle-server.error.log"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,9 +9,9 @@
 
 set -e
 
-INSTALL_DIR="${ORACLE_INSTALL_DIR:-$HOME/.local/share/arra-oracle}"
-REPO_URL="https://github.com/Soul-Brews-Studio/arra-oracle.git"
-REPO_API="https://api.github.com/repos/Soul-Brews-Studio/arra-oracle"
+INSTALL_DIR="${ORACLE_INSTALL_DIR:-$HOME/.local/share/arra-oracle-v3}"
+REPO_URL="https://github.com/Soul-Brews-Studio/arra-oracle-v3.git"
+REPO_API="https://api.github.com/repos/Soul-Brews-Studio/arra-oracle-v3"
 
 echo "🔮 Arra Oracle Installer"
 echo "======================"
@@ -72,7 +72,7 @@ mkdir -p ~/.oracle
 # Add to Claude Code MCP
 echo ""
 echo "📝 Adding to Claude Code..."
-claude mcp add arra-oracle -- bun run "$INSTALL_DIR/src/index.ts" 2>/dev/null || {
+claude mcp add arra-oracle-v3 -- bun run "$INSTALL_DIR/src/index.ts" 2>/dev/null || {
     echo "⚠️  claude mcp add failed - you may need to add manually"
 }
 
@@ -84,7 +84,7 @@ echo "📋 Copy this to your AI (problems @tacha-hash faced):"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 cat << 'EOF'
 
-arra-oracle installed! Please restart Claude Code.
+arra-oracle-v3 installed! Please restart Claude Code.
 
 If you see errors, here are fixes from @tacha-hash's 20-min debug session:
 

--- a/scripts/migrate-data.sh
+++ b/scripts/migrate-data.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Migrate ~/.oracle/ → ~/.arra-oracle-v3/
+# "Nothing is Deleted" — old dir preserved, not removed.
+
+OLD="$HOME/.oracle"
+NEW="$HOME/.arra-oracle-v3"
+
+if [ -d "$NEW" ]; then
+  echo "✓ $NEW already exists — nothing to do"
+  exit 0
+fi
+
+if [ ! -d "$OLD" ]; then
+  echo "⚠ $OLD not found — creating fresh $NEW"
+  mkdir -p "$NEW"
+  exit 0
+fi
+
+echo "Migrating $OLD → $NEW..."
+cp -r "$OLD" "$NEW"
+echo "✓ Migrated $OLD → $NEW"
+echo "  Old dir preserved at $OLD (Nothing is Deleted)"

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -3,7 +3,7 @@
 # This creates a minimal ψ/memory structure for testing
 set -e
 
-SEED_DIR="${ORACLE_SEED_DIR:-$HOME/.oracle/seed}"
+SEED_DIR="${ORACLE_SEED_DIR:-$HOME/.arra-oracle-v3/seed}"
 
 echo "🌱 Creating seed directory at $SEED_DIR..."
 mkdir -p "$SEED_DIR/ψ/memory/resonance"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Setup oracle-v2 with frontend build
+# Setup arra-oracle-v3 with frontend build
 set -e
 
 echo "🔧 Installing root dependencies..."

--- a/src/chroma-mcp.ts
+++ b/src/chroma-mcp.ts
@@ -85,7 +85,7 @@ export class ChromaMcpClient {
       });
 
       this.client = new Client({
-        name: 'arra-oracle-chroma',
+        name: 'arra-oracle-v3-chroma',
         version: '1.0.0'
       }, {
         capabilities: {}

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,12 +19,12 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 // Configuration
 export const PORT = parseInt(String(process.env.ORACLE_PORT || 47778), 10);
 export const HOME_DIR = process.env.HOME || process.env.USERPROFILE || '/tmp';
-export const ORACLE_DATA_DIR = process.env.ORACLE_DATA_DIR || path.join(HOME_DIR, '.oracle');
+export const ORACLE_DATA_DIR = process.env.ORACLE_DATA_DIR || path.join(HOME_DIR, '.arra-oracle-v3');
 export const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, 'oracle.db');
 // REPO_ROOT for features that need knowledge base context
 // When running from source: defaults to project root (where ψ/ lives)
 // When running via bunx: set ORACLE_REPO_ROOT explicitly
-// Fallback: ~/.oracle for bunx installs
+// Fallback: ~/.arra-oracle-v3 for bunx installs
 export const REPO_ROOT = process.env.ORACLE_REPO_ROOT ||
   (fs.existsSync(path.join(PROJECT_ROOT, 'ψ')) ? PROJECT_ROOT : ORACLE_DATA_DIR);
 

--- a/src/config/__tests__/tool-groups.test.ts
+++ b/src/config/__tests__/tool-groups.test.ts
@@ -26,12 +26,12 @@ describe('tool-groups', () => {
       schedule: false, forum: true, trace: false,
     };
     const disabled = getDisabledTools(config);
-    expect(disabled.has('oracle_schedule_add')).toBe(true);
-    expect(disabled.has('oracle_schedule_list')).toBe(true);
-    expect(disabled.has('oracle_trace')).toBe(true);
-    expect(disabled.has('oracle_trace_list')).toBe(true);
-    expect(disabled.has('oracle_search')).toBe(false);
-    expect(disabled.has('oracle_learn')).toBe(false);
+    expect(disabled.has('arra_schedule_add')).toBe(true);
+    expect(disabled.has('arra_schedule_list')).toBe(true);
+    expect(disabled.has('arra_trace')).toBe(true);
+    expect(disabled.has('arra_trace_list')).toBe(true);
+    expect(disabled.has('arra_search')).toBe(false);
+    expect(disabled.has('arra_learn')).toBe(false);
   });
 
   it('defaults to all groups enabled', () => {
@@ -44,10 +44,10 @@ describe('tool-groups', () => {
     expect(config.trace).toBe(true);
   });
 
-  it('all tool names follow oracle_ prefix convention', () => {
+  it('all tool names follow arra_ prefix convention', () => {
     for (const tools of Object.values(TOOL_GROUPS)) {
       for (const tool of tools) {
-        expect(tool).toMatch(/^oracle_/);
+        expect(tool).toMatch(/^arra_/);
       }
     }
   });

--- a/src/config/tool-groups.ts
+++ b/src/config/tool-groups.ts
@@ -4,7 +4,7 @@
  * Controls which tool groups are registered at startup.
  * Config sources (in priority order):
  *   1. arra.config.json in repo root (ORACLE_REPO_ROOT or cwd)
- *   2. ~/.oracle/config.json (global)
+ *   2. ~/.arra-oracle-v3/config.json (global)
  *   3. Defaults: all groups enabled
  */
 
@@ -12,12 +12,12 @@ import fs from 'fs';
 import path from 'path';
 
 export const TOOL_GROUPS = {
-  search: ['oracle_search', 'oracle_read', 'oracle_list', 'oracle_concepts'],
-  knowledge: ['oracle_learn', 'oracle_reflect', 'oracle_stats', 'oracle_supersede', 'oracle_verify'],
-  session: ['oracle_handoff', 'oracle_inbox'],
-  schedule: ['oracle_schedule_add', 'oracle_schedule_list'],
-  forum: ['oracle_thread', 'oracle_threads', 'oracle_thread_read', 'oracle_thread_update'],
-  trace: ['oracle_trace', 'oracle_trace_list', 'oracle_trace_get', 'oracle_trace_link', 'oracle_trace_unlink', 'oracle_trace_chain'],
+  search: ['arra_search', 'arra_read', 'arra_list', 'arra_concepts'],
+  knowledge: ['arra_learn', 'arra_reflect', 'arra_stats', 'arra_supersede', 'arra_verify'],
+  session: ['arra_handoff', 'arra_inbox'],
+  schedule: ['arra_schedule_add', 'arra_schedule_list'],
+  forum: ['arra_thread', 'arra_threads', 'arra_thread_read', 'arra_thread_update'],
+  trace: ['arra_trace', 'arra_trace_list', 'arra_trace_get', 'arra_trace_link', 'arra_trace_unlink', 'arra_trace_chain'],
 } as const;
 
 export type ToolGroupName = keyof typeof TOOL_GROUPS;
@@ -53,10 +53,10 @@ export function loadToolGroupConfig(repoRoot?: string): ToolGroupConfig {
     return { ...DEFAULT_CONFIG, ...localConfig.tools };
   }
 
-  // Priority 2: global ~/.oracle/config.json
-  const globalConfig = readJsonSafe(path.join(homeDir, '.oracle', 'config.json'));
+  // Priority 2: global ~/.arra-oracle-v3/config.json
+  const globalConfig = readJsonSafe(path.join(homeDir, '.arra-oracle-v3', 'config.json'));
   if (globalConfig?.tools) {
-    console.error('[ToolGroups] Using ~/.oracle/config.json');
+    console.error('[ToolGroups] Using ~/.arra-oracle-v3/config.json');
     return { ...DEFAULT_CONFIG, ...globalConfig.tools };
   }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 /**
- * Oracle v2 Database Schema (Drizzle ORM)
+ * Arra Oracle v3 Database Schema (Drizzle ORM)
  *
  * Generated from existing database via drizzle-kit pull,
  * then cleaned up to exclude FTS5 internal tables.
@@ -22,8 +22,8 @@ export const oracleDocuments = sqliteTable('oracle_documents', {
   supersededReason: text('superseded_reason'), // Why (optional)
   // Provenance tracking (Issue #22)
   origin: text('origin'),                   // 'mother' | 'arthur' | 'volt' | 'human' | null (legacy)
-  project: text('project'),                 // ghq-style: 'github.com/laris-co/oracle-v2'
-  createdBy: text('created_by'),            // 'indexer' | 'oracle_learn' | 'manual'
+  project: text('project'),                 // ghq-style: 'github.com/laris-co/arra-oracle-v3'
+  createdBy: text('created_by'),            // 'indexer' | 'arra_learn' | 'manual'
 }, (table) => [
   index('idx_source').on(table.sourceFile),
   index('idx_type').on(table.type),

--- a/src/drizzle-migration.test.ts
+++ b/src/drizzle-migration.test.ts
@@ -209,7 +209,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
       now,
       null,
       'github.com/test/repo',
-      'oracle_learn'
+      'arra_learn'
     );
 
     const result = db.prepare('SELECT * FROM oracle_documents WHERE id = ?').get(id) as any;
@@ -218,7 +218,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
     expect(result.type).toBe('learning');
     expect(result.source_file).toBe('ψ/memory/learnings/test-pattern.md');
     expect(JSON.parse(result.concepts)).toEqual(['test', 'pattern']);
-    expect(result.created_by).toBe('oracle_learn');
+    expect(result.created_by).toBe('arra_learn');
     expect(result.project).toBe('github.com/test/repo');
   });
 
@@ -229,7 +229,7 @@ describe('handleLearn - INSERT oracle_documents', () => {
     db.prepare(`
       INSERT INTO oracle_documents (id, type, source_file, concepts, created_at, updated_at, indexed_at, origin, project, created_by)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, 'learning', 'test.md', '[]', now, now, now, null, null, 'oracle_learn');
+    `).run(id, 'learning', 'test.md', '[]', now, now, now, null, null, 'arra_learn');
 
     const result = db.prepare('SELECT * FROM oracle_documents WHERE id = ?').get(id) as any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,13 +71,13 @@ import type {
 
 // Write tools that should be disabled in read-only mode
 const WRITE_TOOLS = [
-  'oracle_learn',
-  'oracle_thread',
-  'oracle_thread_update',
-  'oracle_trace',
-  'oracle_supersede',
-  'oracle_handoff',
-  'oracle_schedule_add',
+  'arra_learn',
+  'arra_thread',
+  'arra_thread_update',
+  'arra_trace',
+  'arra_supersede',
+  'arra_handoff',
+  'arra_schedule_add',
 ];
 
 class OracleMCPServer {
@@ -114,11 +114,11 @@ class OracleMCPServer {
     const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'));
     this.version = pkg.version;
     this.server = new Server(
-      { name: 'arra-oracle', version: this.version },
+      { name: 'arra-oracle-v3', version: this.version },
       { capabilities: { tools: {} } }
     );
 
-    const oracleDataDir = process.env.ORACLE_DATA_DIR || path.join(homeDir, '.oracle');
+    const oracleDataDir = process.env.ORACLE_DATA_DIR || path.join(homeDir, '.arra-oracle-v3');
     const dbPath = process.env.ORACLE_DB_PATH || path.join(oracleDataDir, 'oracle.db');
     const { sqlite, db } = createDatabase(dbPath);
     this.sqlite = sqlite;
@@ -182,7 +182,7 @@ class OracleMCPServer {
         // Meta-documentation tool
         {
           name: '____IMPORTANT',
-          description: `ORACLE WORKFLOW GUIDE (v${this.version}):\n\n1. SEARCH & DISCOVER\n   oracle_search(query) → Find knowledge by keywords/vectors\n   oracle_read(file/id) → Read full document content\n   oracle_list() → Browse all documents\n   oracle_concepts() → See topic coverage\n\n2. REFLECT\n   oracle_reflect() → Random wisdom for alignment\n\n3. LEARN & REMEMBER\n   oracle_learn(pattern) → Add new patterns/learnings\n   oracle_thread(message) → Multi-turn discussions\n   ⚠️ BEFORE adding: search for similar topics first!\n   If updating old info → use oracle_supersede(oldId, newId)\n\n4. TRACE & DISTILL\n   oracle_trace(query) → Log discovery sessions with dig points\n   oracle_trace_list() → Find past traces\n   oracle_trace_get(id) → Explore dig points (files, commits, issues)\n   oracle_trace_link(prevId, nextId) → Chain related traces together\n   oracle_trace_chain(id) → View the full linked chain\n\n5. HANDOFF & INBOX\n   oracle_handoff(content) → Save session context for next session\n   oracle_inbox() → List pending handoffs\n\n6. SCHEDULE (shared across all Oracles)\n   oracle_schedule_add(date, event) → Add appointment to shared schedule\n   oracle_schedule_list(filter?) → View upcoming events\n   Schedule lives at ~/.oracle/ψ/inbox/schedule.md (per-human, not per-project)\n\n7. SUPERSEDE (when info changes)\n   oracle_supersede(oldId, newId, reason) → Mark old doc as outdated\n   "Nothing is Deleted" — old preserved, just marked superseded\n\n7. VERIFY (health check)\n   oracle_verify(check?) → Compare ψ/ files vs DB index\n   check=true (default): read-only report\n   check=false: also flag orphaned entries\n\nPhilosophy: "Nothing is Deleted" — All interactions logged.`,
+          description: `ORACLE WORKFLOW GUIDE (v${this.version}):\n\n1. SEARCH & DISCOVER\n   arra_search(query) → Find knowledge by keywords/vectors\n   arra_read(file/id) → Read full document content\n   arra_list() → Browse all documents\n   arra_concepts() → See topic coverage\n\n2. REFLECT\n   arra_reflect() → Random wisdom for alignment\n\n3. LEARN & REMEMBER\n   arra_learn(pattern) → Add new patterns/learnings\n   arra_thread(message) → Multi-turn discussions\n   ⚠️ BEFORE adding: search for similar topics first!\n   If updating old info → use arra_supersede(oldId, newId)\n\n4. TRACE & DISTILL\n   arra_trace(query) → Log discovery sessions with dig points\n   arra_trace_list() → Find past traces\n   arra_trace_get(id) → Explore dig points (files, commits, issues)\n   arra_trace_link(prevId, nextId) → Chain related traces together\n   arra_trace_chain(id) → View the full linked chain\n\n5. HANDOFF & INBOX\n   arra_handoff(content) → Save session context for next session\n   arra_inbox() → List pending handoffs\n\n6. SCHEDULE (shared across all Oracles)\n   arra_schedule_add(date, event) → Add appointment to shared schedule\n   arra_schedule_list(filter?) → View upcoming events\n   Schedule lives at ~/.arra-oracle-v3/ψ/inbox/schedule.md (per-human, not per-project)\n\n7. SUPERSEDE (when info changes)\n   arra_supersede(oldId, newId, reason) → Mark old doc as outdated\n   "Nothing is Deleted" — old preserved, just marked superseded\n\n7. VERIFY (health check)\n   arra_verify(check?) → Compare ψ/ files vs DB index\n   check=true (default): read-only report\n   check=false: also flag orphaned entries\n\nPhilosophy: "Nothing is Deleted" — All interactions logged.`,
           inputSchema: { type: 'object', properties: {} }
         },
         // Core tools (from src/tools/)
@@ -222,7 +222,7 @@ class OracleMCPServer {
         return {
           content: [{
             type: 'text',
-            text: `Error: Tool "${request.params.name}" is disabled by tool group config. Check ~/.oracle/config.json or arra.config.json.`
+            text: `Error: Tool "${request.params.name}" is disabled by tool group config. Check ~/.arra-oracle-v3/config.json or arra.config.json.`
           }],
           isError: true
         };
@@ -243,55 +243,55 @@ class OracleMCPServer {
       try {
         switch (request.params.name) {
           // Core tools (delegated to src/tools/)
-          case 'oracle_search':
+          case 'arra_search':
             return await handleSearch(ctx, request.params.arguments as unknown as OracleSearchInput);
-          case 'oracle_read':
+          case 'arra_read':
             return await handleRead(ctx, request.params.arguments as unknown as OracleReadInput);
-          case 'oracle_reflect':
+          case 'arra_reflect':
             return await handleReflect(ctx, request.params.arguments as unknown as OracleReflectInput);
-          case 'oracle_learn':
+          case 'arra_learn':
             return await handleLearn(ctx, request.params.arguments as unknown as OracleLearnInput);
-          case 'oracle_list':
+          case 'arra_list':
             return await handleList(ctx, request.params.arguments as unknown as OracleListInput);
-          case 'oracle_stats':
+          case 'arra_stats':
             return await handleStats(ctx, request.params.arguments as unknown as OracleStatsInput);
-          case 'oracle_concepts':
+          case 'arra_concepts':
             return await handleConcepts(ctx, request.params.arguments as unknown as OracleConceptsInput);
-          case 'oracle_supersede':
+          case 'arra_supersede':
             return await handleSupersede(ctx, request.params.arguments as unknown as OracleSupersededInput);
-          case 'oracle_handoff':
+          case 'arra_handoff':
             return await handleHandoff(ctx, request.params.arguments as unknown as OracleHandoffInput);
-          case 'oracle_inbox':
+          case 'arra_inbox':
             return await handleInbox(ctx, request.params.arguments as unknown as OracleInboxInput);
-          case 'oracle_verify':
+          case 'arra_verify':
             return await handleVerify(ctx, request.params.arguments as unknown as OracleVerifyInput);
-          case 'oracle_schedule_add':
+          case 'arra_schedule_add':
             return await handleScheduleAdd(ctx, request.params.arguments as unknown as OracleScheduleAddInput);
-          case 'oracle_schedule_list':
+          case 'arra_schedule_list':
             return await handleScheduleList(ctx, request.params.arguments as unknown as OracleScheduleListInput);
 
           // Forum tools (delegated to src/tools/forum.ts)
-          case 'oracle_thread':
+          case 'arra_thread':
             return await handleThread(request.params.arguments as unknown as OracleThreadInput);
-          case 'oracle_threads':
+          case 'arra_threads':
             return await handleThreads(request.params.arguments as unknown as OracleThreadsInput);
-          case 'oracle_thread_read':
+          case 'arra_thread_read':
             return await handleThreadRead(request.params.arguments as unknown as OracleThreadReadInput);
-          case 'oracle_thread_update':
+          case 'arra_thread_update':
             return await handleThreadUpdate(request.params.arguments as unknown as OracleThreadUpdateInput);
 
           // Trace tools (delegated to src/tools/trace.ts)
-          case 'oracle_trace':
+          case 'arra_trace':
             return await handleTrace(request.params.arguments as unknown as CreateTraceInput);
-          case 'oracle_trace_list':
+          case 'arra_trace_list':
             return await handleTraceList(request.params.arguments as unknown as ListTracesInput);
-          case 'oracle_trace_get':
+          case 'arra_trace_get':
             return await handleTraceGet(request.params.arguments as unknown as GetTraceInput);
-          case 'oracle_trace_link':
+          case 'arra_trace_link':
             return await handleTraceLink(request.params.arguments as unknown as { prevTraceId: string; nextTraceId: string });
-          case 'oracle_trace_unlink':
+          case 'arra_trace_unlink':
             return await handleTraceUnlink(request.params.arguments as unknown as { traceId: string; direction: 'prev' | 'next' });
-          case 'oracle_trace_chain':
+          case 'arra_trace_chain':
             return await handleTraceChain(request.params.arguments as unknown as { traceId: string });
 
           default:

--- a/src/indexer-preservation.test.ts
+++ b/src/indexer-preservation.test.ts
@@ -1,10 +1,10 @@
 /**
  * Indexer Preservation Tests
  *
- * Tests that oracle_learn documents are preserved during re-indexing.
+ * Tests that arra_learn documents are preserved during re-indexing.
  * This is critical for cross-repo knowledge sharing.
  *
- * Philosophy: "Nothing is Deleted" - oracle_learn docs have no local files
+ * Philosophy: "Nothing is Deleted" - arra_learn docs have no local files
  * and must not be wiped during indexer runs.
  */
 
@@ -146,14 +146,14 @@ function insertTestDoc(doc: {
 // Preservation Tests
 // ============================================================================
 
-describe('Indexer Preservation - oracle_learn documents', () => {
-  it('should preserve oracle_learn documents during re-index', () => {
-    // Insert oracle_learn doc from another repo
+describe('Indexer Preservation - arra_learn documents', () => {
+  it('should preserve arra_learn documents during re-index', () => {
+    // Insert arra_learn doc from another repo
     insertTestDoc({
       id: 'test-oracle-learn-1',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/test.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/other/repo',
     });
 
@@ -169,11 +169,11 @@ describe('Indexer Preservation - oracle_learn documents', () => {
     // Simulate indexer run for current repo
     const deleted = simulateSmartDeletion('github.com/current/repo');
 
-    // Verify oracle_learn doc is preserved
+    // Verify arra_learn doc is preserved
     const preserved = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'test-oracle-learn-1')).get();
     expect(preserved).toBeDefined();
-    expect(preserved?.createdBy).toBe('oracle_learn');
+    expect(preserved?.createdBy).toBe('arra_learn');
 
     // Verify indexer doc was deleted
     const notPreserved = db.select().from(oracleDocuments)
@@ -184,13 +184,13 @@ describe('Indexer Preservation - oracle_learn documents', () => {
     expect(deleted).not.toContain('test-oracle-learn-1');
   });
 
-  it('should preserve oracle_learn docs from different projects', () => {
-    // Insert oracle_learn docs from various projects
+  it('should preserve arra_learn docs from different projects', () => {
+    // Insert arra_learn docs from various projects
     insertTestDoc({
       id: 'learn-repo-a',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/a.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/team/repo-a',
     });
 
@@ -198,14 +198,14 @@ describe('Indexer Preservation - oracle_learn documents', () => {
       id: 'learn-repo-b',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/b.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/team/repo-b',
     });
 
     // Simulate indexer run for repo-a
     simulateSmartDeletion('github.com/team/repo-a');
 
-    // Both oracle_learn docs should be preserved
+    // Both arra_learn docs should be preserved
     const docA = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'learn-repo-a')).get();
     const docB = db.select().from(oracleDocuments)
@@ -280,20 +280,20 @@ describe('Indexer Preservation - project isolation', () => {
     expect(deleted).toContain('project-specific-doc');
   });
 
-  it('should preserve universal oracle_learn docs', () => {
-    // Insert universal oracle_learn doc (created from a context without project detection)
+  it('should preserve universal arra_learn docs', () => {
+    // Insert universal arra_learn doc (created from a context without project detection)
     insertTestDoc({
       id: 'universal-learn-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/universal.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: null,
     });
 
     // Simulate indexer run
     const deleted = simulateSmartDeletion('github.com/any/repo');
 
-    // Universal oracle_learn should be preserved
+    // Universal arra_learn should be preserved
     const doc = db.select().from(oracleDocuments)
       .where(eq(oracleDocuments.id, 'universal-learn-doc')).get();
     expect(doc).toBeDefined();
@@ -352,12 +352,12 @@ describe('Indexer Preservation - FTS sync', () => {
   });
 
   it('should preserve FTS entries for preserved documents', () => {
-    // Insert oracle_learn doc
+    // Insert arra_learn doc
     insertTestDoc({
       id: 'fts-preserved-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/preserved.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/other/repo',
       content: 'This content should remain searchable',
     });
@@ -381,13 +381,13 @@ describe('Indexer Preservation - edge cases', () => {
     expect(deleted).toEqual([]);
   });
 
-  it('should handle database with only oracle_learn docs', () => {
-    // Insert only oracle_learn docs
+  it('should handle database with only arra_learn docs', () => {
+    // Insert only arra_learn docs
     insertTestDoc({
       id: 'only-learn-1',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/1.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/repo/1',
     });
 
@@ -395,7 +395,7 @@ describe('Indexer Preservation - edge cases', () => {
       id: 'only-learn-2',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/2.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/repo/2',
     });
 
@@ -422,7 +422,7 @@ describe('Indexer Preservation - edge cases', () => {
       id: 'oracle-learn-doc',
       type: 'learning',
       sourceFile: 'ψ/memory/learnings/learn.md',
-      createdBy: 'oracle_learn',
+      createdBy: 'arra_learn',
       project: 'github.com/current/repo',
     });
 

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -171,7 +171,7 @@ export class OracleIndexer {
     this.backupDatabase();
 
     // Smart deletion: delete indexer-created docs whose source file no longer exists on disk.
-    // Safe for multi-project vault: only removes docs with missing files, preserves oracle_learn docs.
+    // Safe for multi-project vault: only removes docs with missing files, preserves arra_learn docs.
     const allIndexerDocs = this.db.select({ id: oracleDocuments.id, sourceFile: oracleDocuments.sourceFile })
       .from(oracleDocuments)
       .where(
@@ -182,7 +182,7 @@ export class OracleIndexer {
     const idsToDelete = allIndexerDocs
       .filter(d => !fs.existsSync(path.join(this.config.repoRoot, d.sourceFile)))
       .map(d => d.id);
-    console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving oracle_learn)`);
+    console.log(`Smart delete: ${idsToDelete.length} stale docs (preserving arra_learn)`);
 
     if (idsToDelete.length > 0) {
       // Delete from oracle_documents (Drizzle)

--- a/src/integration/database.test.ts
+++ b/src/integration/database.test.ts
@@ -1,6 +1,6 @@
 /**
  * Database Integration Tests
- * Tests oracle-v2 database operations with Drizzle ORM
+ * Tests arra-oracle-v3 database operations with Drizzle ORM
  * Uses isolated test database with proper migrations
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";

--- a/src/integration/http.test.ts
+++ b/src/integration/http.test.ts
@@ -1,6 +1,6 @@
 /**
  * HTTP API Integration Tests
- * Tests oracle-v2 server endpoints
+ * Tests arra-oracle-v3 server endpoints
  */
 import { describe, test, expect, beforeAll, afterAll } from "bun:test";
 import type { Subprocess } from "bun";

--- a/src/integration/mcp.test.ts
+++ b/src/integration/mcp.test.ts
@@ -1,6 +1,6 @@
 /**
  * MCP (Model Context Protocol) Integration Tests
- * Tests oracle-v2 MCP tools via stdio transport
+ * Tests arra-oracle-v3 MCP tools via stdio transport
  *
  * Requires MCP server to be startable. If the server can't connect,
  * tests fail with a clear message rather than silently skipping.
@@ -141,9 +141,9 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
 
       // Check for core tools
       const toolNames = result.tools.map((t) => t.name);
-      expect(toolNames).toContain("oracle_search");
-      expect(toolNames).toContain("oracle_list");
-      expect(toolNames).toContain("oracle_stats");
+      expect(toolNames).toContain("arra_search");
+      expect(toolNames).toContain("arra_list");
+      expect(toolNames).toContain("arra_stats");
     });
   });
 
@@ -151,8 +151,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Read-Only Tools
   // ===================
   describe("Read-Only Tools", () => {
-    test("oracle_search returns results", async () => {
-      const result = await callTool("oracle_search", {
+    test("arra_search returns results", async () => {
+      const result = await callTool("arra_search", {
         query: "oracle",
         limit: 5,
       });
@@ -161,29 +161,29 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
       expect(typeof result).toBe("object");
     });
 
-    test("oracle_list returns documents", async () => {
-      const result = await callTool("oracle_list", {
+    test("arra_list returns documents", async () => {
+      const result = await callTool("arra_list", {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_stats returns statistics", async () => {
-      const result = await callTool("oracle_stats", {});
+    test("arra_stats returns statistics", async () => {
+      const result = await callTool("arra_stats", {});
       expect(result).toBeDefined();
     });
 
-    test("oracle_concepts returns concept list", async () => {
-      const result = await callTool("oracle_concepts", {
+    test("arra_concepts returns concept list", async () => {
+      const result = await callTool("arra_concepts", {
         limit: 20,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_reflect returns random wisdom", async () => {
-      const result = await callTool("oracle_reflect", {});
+    test("arra_reflect returns random wisdom", async () => {
+      const result = await callTool("arra_reflect", {});
       expect(result).toBeDefined();
     });
   });
@@ -192,16 +192,16 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Thread Tools
   // ===================
   describe("Thread Tools", () => {
-    test("oracle_threads lists threads", async () => {
-      const result = await callTool("oracle_threads", {
+    test("arra_threads lists threads", async () => {
+      const result = await callTool("arra_threads", {
         limit: 10,
       });
 
       expect(result).toBeDefined();
     });
 
-    test("oracle_threads with status filter", async () => {
-      const result = await callTool("oracle_threads", {
+    test("arra_threads with status filter", async () => {
+      const result = await callTool("arra_threads", {
         status: "active",
         limit: 5,
       });
@@ -214,8 +214,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
   // Trace Tools
   // ===================
   describe("Trace Tools", () => {
-    test("oracle_trace_list returns traces", async () => {
-      const result = await callTool("oracle_trace_list", {
+    test("arra_trace_list returns traces", async () => {
+      const result = await callTool("arra_trace_list", {
         limit: 10,
       });
 
@@ -238,8 +238,8 @@ describe.skipIf(!MCP_TEST_ENABLED)("MCP Integration", () => {
 
     test("handles missing required params", async () => {
       try {
-        // oracle_search requires 'query' param
-        await callTool("oracle_search", {});
+        // arra_search requires 'query' param
+        await callTool("arra_search", {});
         // May or may not throw depending on implementation
       } catch (error) {
         expect(error).toBeDefined();

--- a/src/scripts/fix-oracle-learn-project.ts
+++ b/src/scripts/fix-oracle-learn-project.ts
@@ -1,5 +1,5 @@
 /**
- * Fix missing project field for oracle_learn documents
+ * Fix missing project field for arra_learn documents
  * Uses Drizzle ORM - not direct SQL!
  */
 
@@ -10,9 +10,9 @@ import { homedir } from 'os';
 import path from 'path';
 import fs from 'fs';
 
-const REPO_ROOT = path.join(homedir(), 'Code/github.com/Soul-Brews-Studio/arra-oracle');
+const REPO_ROOT = path.join(homedir(), 'Code/github.com/Soul-Brews-Studio/arra-oracle-v3');
 
-// Find all oracle_learn docs without project using Drizzle
+// Find all arra_learn docs without project using Drizzle
 const docs = db.select({
   id: oracleDocuments.id,
   sourceFile: oracleDocuments.sourceFile
@@ -20,13 +20,13 @@ const docs = db.select({
   .from(oracleDocuments)
   .where(
     and(
-      eq(oracleDocuments.createdBy, 'oracle_learn'),
+      eq(oracleDocuments.createdBy, 'arra_learn'),
       or(isNull(oracleDocuments.project), eq(oracleDocuments.project, ''))
     )
   )
   .all();
 
-console.log(`Found ${docs.length} oracle_learn docs without project`);
+console.log(`Found ${docs.length} arra_learn docs without project`);
 
 let fixed = 0;
 let fixedFromFts = 0;
@@ -81,12 +81,12 @@ console.log(`\nDone: ${fixed} fixed (${fixedFromFts} from FTS), ${failed} could 
 /**
  * Extract project from source field in frontmatter
  * Handles formats:
- * - "oracle_learn from github.com/owner/repo"
+ * - "arra_learn from github.com/owner/repo"
  * - "rrr: org/repo" or "rrr: Owner/Repo"
  * - "source: github.com/owner/repo"
  */
 function extractProjectFromSource(content: string): string | null {
-  // Try "oracle_learn from github.com/owner/repo"
+  // Try "arra_learn from github.com/owner/repo"
   const oracleLearnMatch = content.match(/from\s+(github\.com\/[^\/\s]+\/[^\/\s]+)/);
   if (oracleLearnMatch) return oracleLearnMatch[1];
 

--- a/src/server-legacy.ts
+++ b/src/server-legacy.ts
@@ -298,7 +298,7 @@ const server = http.createServer(async (req, res) => {
         return;
 
       case '/api/health':
-        result = { status: 'ok', server: 'arra-oracle', port: PORT, oracleV2: 'connected' };
+        result = { status: 'ok', server: 'arra-oracle-v3', port: PORT, oracleV2: 'connected' };
         break;
 
       case '/api/search':

--- a/src/server.ts
+++ b/src/server.ts
@@ -369,7 +369,7 @@ app.post('/api/settings', async (c) => {
 
 // Health check
 app.get('/api/health', (c) => {
-  return c.json({ status: 'ok', server: 'arra-oracle', port: PORT, oracleV2: 'connected' });
+  return c.json({ status: 'ok', server: 'arra-oracle-v3', port: PORT, oracleV2: 'connected' });
 });
 
 // Search
@@ -495,8 +495,8 @@ app.get('/api/map3d', async (c) => {
   }
 });
 
-// Live Oracle feed (from ~/.oracle/feed.log)
-const FEED_LOG = path.join(process.env.HOME || '/home/nat', '.oracle', 'feed.log');
+// Live Oracle feed (from ~/.arra-oracle-v3/feed.log)
+const FEED_LOG = path.join(process.env.HOME || '/home/nat', '.arra-oracle-v3', 'feed.log');
 app.get('/api/feed', (c) => {
   try {
     const limit = Math.min(200, parseInt(c.req.query('limit') || '50'));
@@ -761,7 +761,7 @@ app.get('/api/session/stats', (c) => {
 
 // Serve raw schedule.md for frontend rendering
 app.get('/api/schedule/md', (c) => {
-  const schedulePath = path.join(process.env.HOME || '/tmp', '.oracle', 'ψ/inbox/schedule.md');
+  const schedulePath = path.join(process.env.HOME || '/tmp', '.arra-oracle-v3', 'ψ/inbox/schedule.md');
   if (fs.existsSync(schedulePath)) {
     return c.text(fs.readFileSync(schedulePath, 'utf-8'));
   }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -1,5 +1,5 @@
 /**
- * Oracle v2 Project Context
+ * Arra Oracle v3 Project Context
  * Detects project context from ghq-format directory paths
  */
 
@@ -7,10 +7,10 @@ import { execSync } from 'child_process';
 
 export interface ProjectContext {
   // From ghq path parsing
-  github: string;      // "https://github.com/laris-co/oracle-v2"
+  github: string;      // "https://github.com/laris-co/arra-oracle-v3"
   owner: string;       // "laris-co"
-  repo: string;        // "oracle-v2"
-  ghqPath: string;     // "github.com/laris-co/oracle-v2"
+  repo: string;        // "arra-oracle-v3"
+  ghqPath: string;     // "github.com/laris-co/arra-oracle-v3"
 
   // Directories
   root: string;        // Git root directory

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1296,7 +1296,7 @@ export function handleLearn(
     indexedAt: now.getTime(),
     origin: origin || null,          // origin: null = universal/mother
     project: resolvedProject || null, // project: null = universal (auto-detected from cwd)
-    createdBy: 'oracle_learn'
+    createdBy: 'arra_learn'
   }).run();
 
   // Insert into FTS (must use raw SQL - Drizzle doesn't support virtual tables)

--- a/src/tools/__tests__/learn.test.ts
+++ b/src/tools/__tests__/learn.test.ts
@@ -55,8 +55,8 @@ describe('extractProjectFromSource', () => {
     expect(extractProjectFromSource('')).toBeNull();
   });
 
-  it('should extract from "oracle_learn from github.com/owner/repo" format', () => {
-    expect(extractProjectFromSource('oracle_learn from github.com/owner/repo session 42'))
+  it('should extract from "arra_learn from github.com/owner/repo" format', () => {
+    expect(extractProjectFromSource('arra_learn from github.com/owner/repo session 42'))
       .toBe('github.com/owner/repo');
   });
 

--- a/src/tools/concepts.ts
+++ b/src/tools/concepts.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleConceptsInput } from './types.ts';
 
 export const conceptsToolDef = {
-  name: 'oracle_concepts',
+  name: 'arra_concepts',
   description: 'List all concept tags in the Oracle knowledge base with document counts. Useful for discovering what topics are covered and filtering searches.',
   inputSchema: {
     type: 'object',

--- a/src/tools/forum.ts
+++ b/src/tools/forum.ts
@@ -48,7 +48,7 @@ export interface OracleThreadUpdateInput {
 // ============================================================================
 
 export const threadToolDef = {
-  name: 'oracle_thread',
+  name: 'arra_thread',
   description: 'Send a message to an Oracle discussion thread. Creates a new thread or continues an existing one. Oracle auto-responds from knowledge base. Use for multi-turn consultations.',
   inputSchema: {
     type: 'object',
@@ -64,7 +64,7 @@ export const threadToolDef = {
 };
 
 export const threadsToolDef = {
-  name: 'oracle_threads',
+  name: 'arra_threads',
   description: 'List Oracle discussion threads. Filter by status to find pending questions or active discussions.',
   inputSchema: {
     type: 'object',
@@ -78,7 +78,7 @@ export const threadsToolDef = {
 };
 
 export const threadReadToolDef = {
-  name: 'oracle_thread_read',
+  name: 'arra_thread_read',
   description: 'Read full message history from a thread. Use to review context before continuing a conversation.',
   inputSchema: {
     type: 'object',
@@ -91,7 +91,7 @@ export const threadReadToolDef = {
 };
 
 export const threadUpdateToolDef = {
-  name: 'oracle_thread_update',
+  name: 'arra_thread_update',
   description: 'Update thread status. Use to close, reopen, or mark threads as answered/pending.',
   inputSchema: {
     type: 'object',

--- a/src/tools/handoff.ts
+++ b/src/tools/handoff.ts
@@ -12,7 +12,7 @@ import { detectProject } from '../server/project-detect.ts';
 import type { ToolContext, ToolResponse, OracleHandoffInput } from './types.ts';
 
 export const handoffToolDef = {
-  name: 'oracle_handoff',
+  name: 'arra_handoff',
   description: 'Write session context to the Oracle inbox for future sessions to pick up. Creates a timestamped markdown file in ψ/inbox/handoff/. Use at end of sessions to preserve context.',
   inputSchema: {
     type: 'object',
@@ -75,7 +75,7 @@ export async function handleHandoff(ctx: ToolContext, input: OracleHandoffInput)
       text: JSON.stringify({
         success: true,
         file: sourceFileRel,
-        message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with oracle_inbox().`
+        message: `Handoff written${vaultRoot ? ' (vault)' : ''}. Next session can read it with arra_inbox().`
       }, null, 2)
     }]
   };

--- a/src/tools/inbox.ts
+++ b/src/tools/inbox.ts
@@ -9,7 +9,7 @@ import fs from 'fs';
 import type { ToolContext, ToolResponse, OracleInboxInput } from './types.ts';
 
 export const inboxToolDef = {
-  name: 'oracle_inbox',
+  name: 'arra_inbox',
   description: 'List and preview pending handoff files from the Oracle inbox. Returns files sorted newest-first with previews.',
   inputSchema: {
     type: 'object',

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -20,7 +20,7 @@ export function coerceConcepts(concepts: unknown): string[] {
 }
 
 export const learnToolDef = {
-  name: 'oracle_learn',
+  name: 'arra_learn',
   description: 'Add a new pattern or learning to the Oracle knowledge base. Creates a markdown file in ψ/memory/learnings/ and indexes it.',
   inputSchema: {
     type: 'object',
@@ -80,7 +80,7 @@ export function normalizeProject(input?: string): string | null {
 
 /**
  * Extract project from source field (fallback).
- * Handles "oracle_learn from github.com/owner/repo" and "rrr: org/repo" formats.
+ * Handles "arra_learn from github.com/owner/repo" and "rrr: org/repo" formats.
  */
 export function extractProjectFromSource(source?: string): string | null {
   if (!source) return null;
@@ -178,7 +178,7 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     indexedAt: now.getTime(),
     origin: null,
     project,
-    createdBy: 'oracle_learn',
+    createdBy: 'arra_learn',
   }).run();
 
   ctx.sqlite.prepare(`

--- a/src/tools/list.ts
+++ b/src/tools/list.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleListInput } from './types.ts';
 
 export const listToolDef = {
-  name: 'oracle_list',
+  name: 'arra_list',
   description: 'List all documents in Oracle knowledge base. Browse without searching - useful for exploring what knowledge exists. Supports pagination and type filtering.',
   inputSchema: {
     type: 'object',

--- a/src/tools/read.ts
+++ b/src/tools/read.ts
@@ -11,8 +11,8 @@ import { getVaultPsiRoot } from '../vault/handler.ts';
 import type { ToolContext, ToolResponse, OracleReadInput } from './types.ts';
 
 export const readToolDef = {
-  name: 'oracle_read',
-  description: 'Read full content of an Oracle document by file path or document ID. Use after oracle_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
+  name: 'arra_read',
+  description: 'Read full content of an Oracle document by file path or document ID. Use after arra_search to retrieve complete file contents. Resolves vault paths, ghq paths, and symlinks server-side.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -22,7 +22,7 @@ export const readToolDef = {
       },
       id: {
         type: 'string',
-        description: 'Document ID from oracle_search results. Looks up source_file from DB.',
+        description: 'Document ID from arra_search results. Looks up source_file from DB.',
       },
     },
   },

--- a/src/tools/reflect.ts
+++ b/src/tools/reflect.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleReflectInput } from './types.ts';
 
 export const reflectToolDef = {
-  name: 'oracle_reflect',
+  name: 'arra_reflect',
   description: 'Get a random principle or learning for reflection. Use this for periodic wisdom or to align with Oracle philosophy.',
   inputSchema: {
     type: 'object',

--- a/src/tools/schedule.ts
+++ b/src/tools/schedule.ts
@@ -2,7 +2,7 @@
  * Oracle Schedule Handler (Drizzle DB)
  *
  * Source of truth: `schedule` table in oracle.db
- * Auto-exports to ~/.oracle/ψ/inbox/schedule.md on write.
+ * Auto-exports to ~/.arra-oracle-v3/ψ/inbox/schedule.md on write.
  *
  * Supports:
  * - Add/list events with proper YYYY-MM-DD date queries
@@ -21,7 +21,7 @@ import type { ToolContext, ToolResponse, OracleScheduleAddInput, OracleScheduleL
 const SCHEDULE_REL = 'ψ/inbox/schedule.md';
 
 function getSchedulePath(): string {
-  return path.join(os.homedir(), '.oracle', SCHEDULE_REL);
+  return path.join(os.homedir(), '.arra-oracle-v3', SCHEDULE_REL);
 }
 
 const MONTHS: Record<string, number> = {
@@ -116,7 +116,7 @@ function fmtLocal(d: Date): string {
 // ============================================================================
 
 export const scheduleAddToolDef = {
-  name: 'oracle_schedule_add',
+  name: 'arra_schedule_add',
   description: 'Add an appointment or event to the shared schedule. The schedule is per-human (not per-project) and shared across all Oracles.',
   inputSchema: {
     type: 'object',
@@ -148,7 +148,7 @@ export const scheduleAddToolDef = {
 };
 
 export const scheduleListToolDef = {
-  name: 'oracle_schedule_list',
+  name: 'arra_schedule_list',
   description: 'List appointments from the shared schedule. Filter by date, range, or keyword. Defaults to today + 14 days.',
   inputSchema: {
     type: 'object',
@@ -339,7 +339,7 @@ function exportScheduleToMarkdown(ctx: ToolContext): void {
     }
   }
 
-  md += `\n---\n\nManaged by Oracle. Add events via \`oracle_schedule_add\` or the web UI.\n`;
+  md += `\n---\n\nManaged by Oracle. Add events via \`arra_schedule_add\` or the web UI.\n`;
 
   const schedulePath = getSchedulePath();
   fs.mkdirSync(path.dirname(schedulePath), { recursive: true });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -12,7 +12,7 @@ import { ensureVectorStoreConnected } from '../vector/factory.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
 
 export const searchToolDef = {
-  name: 'oracle_search',
+  name: 'arra_search',
   description: 'Search Oracle knowledge base using hybrid search (FTS5 keywords + ChromaDB vectors). Finds relevant principles, patterns, learnings, or retrospectives. Falls back to FTS5-only if ChromaDB unavailable.',
   inputSchema: {
     type: 'object',

--- a/src/tools/stats.ts
+++ b/src/tools/stats.ts
@@ -9,7 +9,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleStatsInput } from './types.ts';
 
 export const statsToolDef = {
-  name: 'oracle_stats',
+  name: 'arra_stats',
   description: 'Get Oracle knowledge base statistics and health status. Returns document counts by type, indexing status, and ChromaDB connection status.',
   inputSchema: {
     type: 'object',

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -10,7 +10,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import type { ToolContext, ToolResponse, OracleSupersededInput } from './types.ts';
 
 export const supersedeToolDef = {
-  name: 'oracle_supersede',
+  name: 'arra_supersede',
   description: 'Mark an old learning/document as superseded by a newer one. Aligns with "Nothing is Deleted" - old doc preserved but marked outdated.',
   inputSchema: {
     type: 'object',

--- a/src/tools/trace.ts
+++ b/src/tools/trace.ts
@@ -28,7 +28,7 @@ import type { ToolResponse } from './types.ts';
 // ============================================================================
 
 export const traceToolDef = {
-  name: 'oracle_trace',
+  name: 'arra_trace',
   description: 'Log a trace session with dig points (files, commits, issues found). Use to capture /trace command results for future exploration.',
   inputSchema: {
     type: 'object',
@@ -51,7 +51,7 @@ export const traceToolDef = {
 };
 
 export const traceListToolDef = {
-  name: 'oracle_trace_list',
+  name: 'arra_trace_list',
   description: 'List recent traces with optional filters. Returns trace summaries for browsing.',
   inputSchema: {
     type: 'object',
@@ -67,7 +67,7 @@ export const traceListToolDef = {
 };
 
 export const traceGetToolDef = {
-  name: 'oracle_trace_get',
+  name: 'arra_trace_get',
   description: 'Get full details of a specific trace including all dig points (files, commits, issues).',
   inputSchema: {
     type: 'object',
@@ -80,7 +80,7 @@ export const traceGetToolDef = {
 };
 
 export const traceLinkToolDef = {
-  name: 'oracle_trace_link',
+  name: 'arra_trace_link',
   description: 'Link two traces as a chain (prev \u2192 next). Creates bidirectional navigation without deleting anything. Use when agents create related traces that should be connected.',
   inputSchema: {
     type: 'object',
@@ -93,7 +93,7 @@ export const traceLinkToolDef = {
 };
 
 export const traceUnlinkToolDef = {
-  name: 'oracle_trace_unlink',
+  name: 'arra_trace_unlink',
   description: 'Remove a link between traces. Breaks the chain connection in the specified direction.',
   inputSchema: {
     type: 'object',
@@ -106,7 +106,7 @@ export const traceUnlinkToolDef = {
 };
 
 export const traceChainToolDef = {
-  name: 'oracle_trace_chain',
+  name: 'arra_trace_chain',
   description: 'Get the full linked chain for a trace. Returns all traces in the chain and the position of the requested trace.',
   inputSchema: {
     type: 'object',
@@ -148,7 +148,7 @@ export async function handleTrace(input: CreateTraceInput): Promise<ToolResponse
           issue_count: result.summary.issueCount,
           total_dig_points: result.summary.totalDigPoints,
         },
-        message: `Trace logged. Use oracle_trace_get with trace_id="${result.traceId}" to explore dig points.`
+        message: `Trace logged. Use arra_trace_get with trace_id="${result.traceId}" to explore dig points.`
       }, null, 2)
     }]
   };

--- a/src/tools/verify.ts
+++ b/src/tools/verify.ts
@@ -8,7 +8,7 @@ import { verifyKnowledgeBase } from '../verify/handler.ts';
 import type { ToolContext, ToolResponse, OracleVerifyInput } from './types.ts';
 
 export const verifyToolDef = {
-  name: 'oracle_verify',
+  name: 'arra_verify',
   description: 'Verify knowledge base integrity: compare ψ/ files on disk vs DB index. Detects missing (on disk, not indexed), orphaned (in DB, file gone), and drifted (file changed since last index) documents.',
   inputSchema: {
     type: 'object',

--- a/src/trace/handler.ts
+++ b/src/trace/handler.ts
@@ -478,7 +478,7 @@ export function distillTrace(
     .where(eq(traceLog.traceId, input.traceId))
     .run();
 
-  // TODO: If promoteToLearning, call oracle_learn
+  // TODO: If promoteToLearning, call arra_learn
   // This would require access to the learn function
 
   return {

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,7 @@ export interface OracleReflectInput {
 }
 
 /**
- * oracle_list input - browse documents without search query
+ * arra_list input - browse documents without search query
  */
 export interface OracleListInput {
   type?: OracleDocumentType | 'all';
@@ -88,7 +88,7 @@ export interface OracleReflectOutput {
 }
 
 /**
- * oracle_list output - paginated document list
+ * arra_list output - paginated document list
  */
 export interface OracleListOutput {
   documents: Array<{

--- a/src/vault/cli.ts
+++ b/src/vault/cli.ts
@@ -3,7 +3,7 @@
  * Oracle Vault CLI
  *
  * Global CLI for managing the Oracle knowledge vault.
- * Can be run from any repo after `bun add -g @laris-co/arra-oracle`.
+ * Can be run from any repo after `bun add -g @laris-co/arra-oracle-v3`.
  *
  * Usage:
  *   oracle-vault init <owner/repo>
@@ -25,8 +25,8 @@ const VERSION = '0.4.0-nightly';
 const HELP = `
 oracle-vault v${VERSION} — Central knowledge brain for Oracle
 
-The vault repo IS your central ψ/. Once initialized, oracle_learn and
-oracle_handoff write directly to the vault repo with project-nested paths.
+The vault repo IS your central ψ/. Once initialized, arra_learn and
+arra_handoff write directly to the vault repo with project-nested paths.
 The indexer scans the vault repo for cross-project search. Sync commits
 and pushes to GitHub for backup.
 
@@ -52,9 +52,9 @@ Environment:
 
 How it works:
   1. oracle-vault init <repo>   Clone vault repo via ghq, save to settings
-  2. oracle_learn / handoff     Write directly to vault repo (project-nested)
+  2. arra_learn / handoff     Write directly to vault repo (project-nested)
   3. bun src/indexer.ts          Scan vault repo, index all projects
-  4. oracle_search               Cross-project search results
+  4. arra_search               Cross-project search results
   5. oracle-vault sync           git add + commit + push (backup)
 
 Examples:

--- a/src/vault/handler.ts
+++ b/src/vault/handler.ts
@@ -173,7 +173,7 @@ export function parseGitStatus(porcelainOutput: string): GitStatusCounts {
 // ---------------------------------------------------------------------------
 
 /**
- * Resolve the vault ψ/ root for shared use by oracle_learn, oracle_handoff, indexer, etc.
+ * Resolve the vault ψ/ root for shared use by arra_learn, arra_handoff, indexer, etc.
  * Returns the vault repo local path, or a setup hint if not configured.
  */
 export function getVaultPsiRoot(): { path: string } | { needsInit: true; hint: string } {
@@ -221,8 +221,8 @@ export function initVault(repo: string): InitResult {
   setSetting('vault_repo', repo);
   setSetting('vault_enabled', 'true');
 
-  // 3. Create ~/.oracle/ψ symlink → vault repo's ψ/
-  const oracleHome = path.join(os.homedir(), '.oracle');
+  // 3. Create ~/.arra-oracle-v3/ψ symlink → vault repo's ψ/
+  const oracleHome = path.join(os.homedir(), '.arra-oracle-v3');
   const psiSymlink = path.join(oracleHome, 'ψ');
   const vaultPsiDir = path.join(vaultPath, 'ψ');
 

--- a/src/vector/factory.ts
+++ b/src/vector/factory.ts
@@ -57,7 +57,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     case 'sqlite-vec': {
       const dbPath = config.dataPath
         || process.env.ORACLE_VECTOR_DB_PATH
-        || path.join(home,'.oracle', 'vectors.db');
+        || path.join(home,'.arra-oracle-v3', 'vectors.db');
 
       const embeddingType = config.embeddingProvider
         || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
@@ -73,7 +73,7 @@ export function createVectorStore(config: VectorStoreConfig = {}): VectorStoreAd
     case 'lancedb': {
       const dbPath = config.dataPath
         || process.env.ORACLE_VECTOR_DB_PATH
-        || path.join(home,'.oracle', 'lancedb');
+        || path.join(home,'.arra-oracle-v3', 'lancedb');
 
       const embeddingType = config.embeddingProvider
         || (process.env.ORACLE_EMBEDDING_PROVIDER as EmbeddingProviderType)
@@ -148,17 +148,17 @@ export function getEmbeddingModels(): Record<string, { collection: string; model
       nomic: {
         collection: 'oracle_knowledge',
         model: 'nomic-embed-text',
-        dataPath: path.join(home, '.oracle', 'lancedb'),
+        dataPath: path.join(home, '.arra-oracle-v3', 'lancedb'),
       },
       qwen3: {
         collection: 'oracle_knowledge_qwen3',
         model: 'qwen3-embedding',
-        dataPath: path.join(home, '.oracle', 'lancedb'),
+        dataPath: path.join(home, '.arra-oracle-v3', 'lancedb'),
       },
       'bge-m3': {
         collection: 'oracle_knowledge_bge_m3',
         model: 'bge-m3',
-        dataPath: path.join(home, '.oracle', 'lancedb'),
+        dataPath: path.join(home, '.arra-oracle-v3', 'lancedb'),
       },
     };
   }

--- a/src/verify/handler.ts
+++ b/src/verify/handler.ts
@@ -171,7 +171,7 @@ export function verifyKnowledgeBase(opts: {
             .set({
               supersededBy: '_verified_orphan',
               supersededAt: now,
-              supersededReason: 'File missing from disk (oracle_verify)',
+              supersededReason: 'File missing from disk (arra_verify)',
             })
             .where(eq(oracleDocuments.id, id))
             .run();


### PR DESCRIPTION
## Summary
- Package renamed: `arra-oracle` → `arra-oracle-v3`
- 23 MCP tools renamed: `oracle_*` → `arra_*` (e.g. `arra_search`, `arra_learn`, `arra_thread`)
- Data dir: `~/.oracle/` → `~/.arra-oracle-v3/`
- MCP server name: `arra-oracle` → `arra-oracle-v3`
- Cleaned all stale `oracle-v2` refs left from PR #423
- Added `scripts/migrate-data.sh` for data migration (copy, not move — Nothing is Deleted)

## Changes
- **54 files changed** (278 insertions, 256 deletions)
- All **208 tests pass** (207 existing + 1 updated prefix convention test)

## Migration Steps (after merge)
1. Run `scripts/migrate-data.sh` to copy `~/.oracle/` → `~/.arra-oracle-v3/`
2. Rename GitHub repo: `gh repo rename arra-oracle-v3`
3. Update ecosystem: oracle-skills-cli, 19+ Oracle CLAUDE.md configs (Phase 5, separate PRs)

## Test plan
- [x] `bun test` — 208 pass, 0 fail
- [ ] Start MCP server: `bun src/index.ts` — tools registered as `arra_*`
- [ ] HTTP health: `bun src/server.ts` → `"server": "arra-oracle-v3"`
- [ ] Verify `~/.arra-oracle-v3/` is created on fresh start

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)