### PR TITLE
feat: add ORACLE_HOSTNAME env support

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 
 // Configuration
 export const PORT = parseInt(String(process.env.ORACLE_PORT || 47778), 10);
+export const HOSTNAME = process.env.ORACLE_HOSTNAME || '0.0.0.0';
 export const HOME_DIR = process.env.HOME || process.env.USERPROFILE || '/tmp';
 export const ORACLE_DATA_DIR = process.env.ORACLE_DATA_DIR || path.join(HOME_DIR, '.arra-oracle-v3');
 export const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, 'oracle.db');

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { getVaultPsiRoot } from './vault/handler.ts';
 // Config constants (no DB dependency)
 import {
   PORT,
+  HOSTNAME,
   ORACLE_DATA_DIR,
   REPO_ROOT,
   DB_PATH,
@@ -1257,5 +1258,6 @@ console.log(`
 
 export default {
   port: Number(PORT),
+  hostname: HOSTNAME,
   fetch: app.fetch,
 };


### PR DESCRIPTION
## Summary
- เพิ่ม `ORACLE_HOSTNAME` env var ใน config.ts (default: `0.0.0.0`)
- ส่ง `hostname` ให้ Bun.serve ใน server.ts
- ใช้ `ORACLE_HOSTNAME=127.0.0.1` สำหรับ internal-only deployment

## Changes (3 lines, 2 files)
- `src/config.ts`: export HOSTNAME from env
- `src/server.ts`: import HOSTNAME + add to export default

## Test plan
- [x] Build สำเร็จ
- [x] Start server with `ORACLE_HOSTNAME=127.0.0.1` → binds to 127.0.0.1 only
- [x] `/api/health` returns OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)