### PR TITLE
fix(indexer): FTS5 dedupe + WAL checkpoint before backup

### DIFF
--- a/src/indexer/backup.ts
+++ b/src/indexer/backup.ts
@@ -21,8 +21,16 @@ export function backupDatabase(sqlite: Database, config: IndexerConfig): void {
   const jsonPath = `${config.dbPath}.export-${timestamp}.json`;
   const csvPath = `${config.dbPath}.export-${timestamp}.csv`;
 
-  // 1. Copy SQLite file
+  // 1. Copy SQLite file. Checkpoint the WAL first so all in-flight writes
+  //    are flushed to the main DB file — otherwise fs.copyFileSync produces
+  //    an incomplete backup (we hit this on 2026-04-16: live DB had 591 FTS
+  //    rows but the copied .db file only had 134 checkpointed).
   try {
+    try {
+      sqlite.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    } catch (e) {
+      console.warn(`\u26a0\ufe0f WAL checkpoint failed (backup may be incomplete): ${e instanceof Error ? e.message : e}`);
+    }
     fs.copyFileSync(config.dbPath, backupPath);
     console.log(`\u{1f4e6} DB backup: ${backupPath}`);
   } catch (e) {

--- a/src/indexer/storage.ts
+++ b/src/indexer/storage.ts
@@ -22,9 +22,14 @@ export async function storeDocuments(
 ): Promise<void> {
   const now = Date.now();
 
-  // Prepare FTS statement (raw SQL required for FTS5)
+  // Prepare FTS statements. FTS5 virtual tables have no UNIQUE constraint on
+  // the id column (it's UNINDEXED), so INSERT OR REPLACE doesn't dedupe —
+  // every reindex accumulates duplicates. Delete-then-insert instead.
+  // (Drift discovered 2026-04-16: oracle_fts had 1268 rows for 141 unique ids
+  // after 9 reindex passes.)
+  const deleteFts = sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`);
   const insertFts = sqlite.prepare(`
-    INSERT OR REPLACE INTO oracle_fts (id, content, concepts)
+    INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
   `);
 
@@ -66,7 +71,9 @@ export async function storeDocuments(
         })
         .run();
 
-      // SQLite FTS (raw SQL required for FTS5)
+      // SQLite FTS (raw SQL required for FTS5): delete then insert to avoid
+      // duplicates across re-index runs.
+      deleteFts.run(doc.id);
       insertFts.run(
         doc.id,
         doc.content,

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -1306,7 +1306,9 @@ export function handleLearn(
     createdBy: 'arra_learn'
   }).run();
 
-  // Insert into FTS (must use raw SQL - Drizzle doesn't support virtual tables)
+  // Insert into FTS (must use raw SQL - Drizzle doesn't support virtual tables).
+  // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
+  sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
   sqlite.prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)


### PR DESCRIPTION
## Summary

Two SQLite correctness bugs discovered 2026-04-16 during vault investigation.

### 1. FTS5 duplicate accumulation across reindex runs

`oracle_fts` is a virtual table with no UNIQUE constraint on `id` — repeated `INSERT OR REPLACE` does **not** dedupe. Each reindex/learn call appends another row for the same id.

**Observed:** 1268 FTS rows for 141 unique ids after 9 reindex passes.

**Fix:** `DELETE FROM oracle_fts WHERE id = ?` before `INSERT`. Applied in two write paths:
- `src/indexer/storage.ts` — indexer reindex path
- `src/server/handlers.ts` — HTTP `handleLearn` path

### 2. SQLite backup incomplete when WAL is not checkpointed

`fs.copyFileSync` on the live DB file only captures what is in the main file, not the WAL.

**Observed 2026-04-16:** live DB had 591 FTS rows but the copied backup file had only 134 checkpointed rows.

**Fix:** `PRAGMA wal_checkpoint(TRUNCATE)` before the copy in `src/indexer/backup.ts`.

## Test plan
- [ ] Reindex 3× — FTS row count stable, not accumulating
- [ ] Take DB backup during active writes — row counts match live DB
- [ ] arra_learn same id twice in succession — only one FTS row