### PR TITLE
fix(config): ORACLE_DATA_DIR wins over PROJECT_ROOT for REPO_ROOT

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,10 +27,19 @@ export const PORT = parseInt(String(process.env.ORACLE_PORT || C.ORACLE_DEFAULT_
 export const ORACLE_DATA_DIR = process.env.ORACLE_DATA_DIR || path.join(HOME_DIR, C.ORACLE_DATA_DIR_NAME);
 export const DB_PATH = process.env.ORACLE_DB_PATH || path.join(ORACLE_DATA_DIR, C.ORACLE_DB_FILE);
 
-// REPO_ROOT: where ψ/ lives
-// From source: project root. Via bunx: set ORACLE_REPO_ROOT. Fallback: data dir.
+// REPO_ROOT: where ψ/ lives.
+// Priority:
+//   1. ORACLE_REPO_ROOT env var — explicit override
+//   2. ORACLE_DATA_DIR if it has ψ/ — canonical data location (outside code repo)
+//   3. PROJECT_ROOT if it has ψ/ — dev mode for indexing the oracle's own psi
+//   4. ORACLE_DATA_DIR — default (will be empty initially)
+//
+// Data dir wins over project root so that accidental ψ/ folders in a source
+// checkout (e.g. from arra_learn writing with no vault configured) don't
+// override the real indexed data at ~/.arra-oracle-v2/ψ/.
 export const REPO_ROOT = process.env.ORACLE_REPO_ROOT ||
-  (fs.existsSync(path.join(PROJECT_ROOT, 'ψ')) ? PROJECT_ROOT : ORACLE_DATA_DIR);
+  (fs.existsSync(path.join(ORACLE_DATA_DIR, '\u03c8')) ? ORACLE_DATA_DIR :
+   fs.existsSync(path.join(PROJECT_ROOT, '\u03c8')) ? PROJECT_ROOT : ORACLE_DATA_DIR);
 
 // Derived paths — import these, don't compute inline
 export const FEED_LOG = path.join(ORACLE_DATA_DIR, C.FEED_LOG_FILE);

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -76,6 +76,18 @@ export function registerFileRoutes(app: Hono) {
         return c.text(content);
       }
 
+      // Fallback: some files carry a project frontmatter tag but physically
+      // live in the universal vault (REPO_ROOT / ORACLE_DATA_DIR / ψ/), not
+      // in the project's ghq checkout. Try REPO_ROOT before giving up.
+      if (project) {
+        const repoFullPath = path.join(REPO_ROOT, filePath);
+        const realRepoFullPath = path.resolve(repoFullPath);
+        if (realRepoFullPath.startsWith(realRepoRoot) && fs.existsSync(repoFullPath)) {
+          const content = fs.readFileSync(repoFullPath, 'utf-8');
+          return c.text(content);
+        }
+      }
+
       const vault = getVaultPsiRoot();
       if ('path' in vault) {
         const vaultFullPath = path.join(vault.path, filePath);


### PR DESCRIPTION
## Summary

Two related small fixes around where Oracle looks for ψ/ content.

### 1. \`src/config.ts\` — REPO_ROOT priority

An accidentally-created \`ψ/\` folder in the source checkout (created when \`arra_learn\` falls back to cwd because \`vault_repo\` isn't configured) was winning REPO_ROOT resolution over the real indexed data at \`~/.arra-oracle-v2/ψ/\`.

**New priority:**
1. \`ORACLE_REPO_ROOT\` env var
2. \`ORACLE_DATA_DIR\` if it has \`ψ/\` ← canonical data location
3. \`PROJECT_ROOT\` if it has \`ψ/\` ← dev mode
4. \`ORACLE_DATA_DIR\` default

### 2. \`src/routes/files.ts\` — REPO_ROOT fallback

\`GET /api/files\` was 404'ing on docs that carry a \`project:\` frontmatter tag but physically live in the universal vault (REPO_ROOT/ψ/...). Added a fallback read from REPO_ROOT for project-tagged docs before giving up.

## Test plan
- [ ] Reindex from \`~/.arra-oracle-v2\` when a stray \`ψ/\` exists in the source repo — indexer reads data dir, not stray
- [ ] \`GET /api/files?path=ψ/memory/learnings/<file>\` returns content when file lives in the universal vault