### PR TITLE
feat(supersede): read from oracle_documents + enrich search results

### DIFF
--- a/src/routes/supersede.ts
+++ b/src/routes/supersede.ts
@@ -1,82 +1,127 @@
 /**
  * Supersede Routes — /api/supersede, /api/supersede/chain (Issue #18, #19)
+ *
+ * Source of truth: `oracle_documents.superseded_by/at/reason` columns.
+ * These are populated by `arra_supersede` MCP tool (src/tools/supersede.ts).
+ * The legacy `supersede_log` table is kept for POST /api/supersede backwards
+ * compatibility but is no longer the read source — it was disconnected from
+ * the MCP write path (drift discovered 2026-04-16, see learning
+ * `reindex-wiped-db-clits-fallback-wal-incomple` in the vault).
  */
 
 import type { Hono } from 'hono';
-import { eq, desc, sql } from 'drizzle-orm';
-import { db, supersedeLog } from '../db/index.ts';
+import { eq, isNotNull, desc, sql, and } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/sqlite-core';
+import { db, supersedeLog, oracleDocuments } from '../db/index.ts';
 
 export function registerSupersedeRoutes(app: Hono) {
-  // List supersessions with optional filters
+  // List supersessions from oracle_documents.superseded_by
   app.get('/api/supersede', (c) => {
     const project = c.req.query('project');
     const limit = parseInt(c.req.query('limit') || '50');
     const offset = parseInt(c.req.query('offset') || '0');
 
-    const whereClause = project ? eq(supersedeLog.project, project) : undefined;
+    const projectFilter = project ? eq(oracleDocuments.project, project) : undefined;
+    const whereClause = projectFilter
+      ? and(isNotNull(oracleDocuments.supersededBy), projectFilter)
+      : isNotNull(oracleDocuments.supersededBy);
 
     const countResult = db.select({ total: sql<number>`count(*)` })
-      .from(supersedeLog)
+      .from(oracleDocuments)
       .where(whereClause)
       .get();
     const total = countResult?.total || 0;
 
-    const logs = db.select()
-      .from(supersedeLog)
+    // Self-join to pull the replacement doc's source_file + type
+    const newDoc = alias(oracleDocuments, 'new_doc');
+    const rows = db.select({
+      oldId: oracleDocuments.id,
+      oldPath: oracleDocuments.sourceFile,
+      oldType: oracleDocuments.type,
+      newId: oracleDocuments.supersededBy,
+      newPath: newDoc.sourceFile,
+      newType: newDoc.type,
+      reason: oracleDocuments.supersededReason,
+      supersededAt: oracleDocuments.supersededAt,
+      project: oracleDocuments.project,
+    })
+      .from(oracleDocuments)
+      .leftJoin(newDoc, eq(oracleDocuments.supersededBy, newDoc.id))
       .where(whereClause)
-      .orderBy(desc(supersedeLog.supersededAt))
+      .orderBy(desc(oracleDocuments.supersededAt))
       .limit(limit)
       .offset(offset)
       .all();
 
     return c.json({
-      supersessions: logs.map(log => ({
-        id: log.id,
-        old_path: log.oldPath,
-        old_id: log.oldId,
-        old_title: log.oldTitle,
-        old_type: log.oldType,
-        new_path: log.newPath,
-        new_id: log.newId,
-        new_title: log.newTitle,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString(),
-        superseded_by: log.supersededBy,
-        project: log.project
+      supersessions: rows.map(r => ({
+        old_id: r.oldId,
+        old_path: r.oldPath,
+        old_type: r.oldType,
+        new_id: r.newId,
+        new_path: r.newPath,
+        new_type: r.newType,
+        reason: r.reason,
+        superseded_at: r.supersededAt ? new Date(r.supersededAt).toISOString() : null,
+        project: r.project,
       })),
       total,
       limit,
-      offset
+      offset,
     });
   });
 
-  // Get supersede chain for a document
+  // Get supersede chain for a document (by source_file path)
   app.get('/api/supersede/chain/:path', (c) => {
     const docPath = decodeURIComponent(c.req.param('path'));
 
-    const asOld = db.select()
-      .from(supersedeLog)
-      .where(eq(supersedeLog.oldPath, docPath))
-      .orderBy(supersedeLog.supersededAt)
-      .all();
+    // Resolve the path to a doc id first
+    const target = db.select({ id: oracleDocuments.id })
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.sourceFile, docPath))
+      .get();
 
-    const asNew = db.select()
-      .from(supersedeLog)
-      .where(eq(supersedeLog.newPath, docPath))
-      .orderBy(supersedeLog.supersededAt)
+    if (!target) {
+      return c.json({ superseded_by: [], supersedes: [] });
+    }
+
+    const newDoc = alias(oracleDocuments, 'new_doc');
+
+    // Docs that supersede this one (this.superseded_by → that doc)
+    const asOld = db.select({
+      newPath: newDoc.sourceFile,
+      reason: oracleDocuments.supersededReason,
+      supersededAt: oracleDocuments.supersededAt,
+    })
+      .from(oracleDocuments)
+      .leftJoin(newDoc, eq(oracleDocuments.supersededBy, newDoc.id))
+      .where(eq(oracleDocuments.id, target.id))
+      .orderBy(oracleDocuments.supersededAt)
+      .all()
+      .filter(r => r.newPath !== null);
+
+    // Docs that this one supersedes (their superseded_by === target.id)
+    const asNew = db.select({
+      oldPath: oracleDocuments.sourceFile,
+      reason: oracleDocuments.supersededReason,
+      supersededAt: oracleDocuments.supersededAt,
+    })
+      .from(oracleDocuments)
+      .where(eq(oracleDocuments.supersededBy, target.id))
+      .orderBy(oracleDocuments.supersededAt)
       .all();
 
     return c.json({
-      superseded_by: asOld.map(log => ({
-        new_path: log.newPath,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString()
+      superseded_by: asOld.map(r => ({
+        new_path: r.newPath,
+        reason: r.reason,
+        superseded_at: r.supersededAt ? new Date(r.supersededAt).toISOString() : null,
       })),
-      supersedes: asNew.map(log => ({
-        old_path: log.oldPath,
-        reason: log.reason,
-        superseded_at: new Date(log.supersededAt).toISOString()
-      }))
+      supersedes: asNew.map(r => ({
+        old_path: r.oldPath,
+        reason: r.reason,
+        superseded_at: r.supersededAt ? new Date(r.supersededAt).toISOString() : null,
+      })),
     });
   });
 

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -392,7 +392,35 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
 
   const combinedResults = combineResults(ftsResults, normalizedVectorResults);
   const totalMatches = combinedResults.length;
-  const results = combinedResults.slice(offset, offset + limit);
+  const results: Array<Record<string, unknown>> = combinedResults.slice(offset, offset + limit);
+
+  // Enrich with supersede flags (P-001 "Nothing is Deleted" — superseded docs
+  // remain searchable; callers need to see the flag to decide whether to
+  // follow the replacement pointer). Fixes drift where arra_supersede claimed
+  // "will appear in searches with a warning" but search never flagged them.
+  if (results.length > 0) {
+    const ids = results.map(r => r.id as string);
+    const placeholders = ids.map(() => '?').join(',');
+    const supersedeRows = ctx.sqlite.prepare(`
+      SELECT id, superseded_by, superseded_at, superseded_reason
+      FROM oracle_documents
+      WHERE id IN (${placeholders}) AND superseded_by IS NOT NULL
+    `).all(...ids) as Array<{
+      id: string;
+      superseded_by: string;
+      superseded_at: number;
+      superseded_reason: string | null;
+    }>;
+    const supersedeMap = new Map(supersedeRows.map(r => [r.id, r]));
+    for (const r of results) {
+      const s = supersedeMap.get(r.id as string);
+      if (s) {
+        r.superseded_by = s.superseded_by;
+        r.superseded_at = new Date(s.superseded_at).toISOString();
+        r.superseded_reason = s.superseded_reason;
+      }
+    }
+  }
 
   const ftsCount = results.filter((r) => r.source === 'fts').length;
   const vectorCount = results.filter((r) => r.source === 'vector').length;

--- a/src/tools/supersede.ts
+++ b/src/tools/supersede.ts
@@ -70,7 +70,7 @@ export async function handleSupersede(ctx: ToolContext, input: OracleSupersededI
         new_type: newDoc.type,
         reason: reason || null,
         superseded_at: new Date(now).toISOString(),
-        message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in searches with a warning.`
+        message: `"${oldId}" is now marked as superseded by "${newId}". It will still appear in search results (P-001 Nothing is Deleted), now flagged with "superseded_by", "superseded_at", and "superseded_reason" fields so callers can follow the replacement pointer.`
       }, null, 2)
     }]
   };


### PR DESCRIPTION
## Summary

Fix two drift points in the supersede feature.

### 1. \`/api/supersede\` route read stale data

\`arra_supersede\` (MCP tool) writes to \`oracle_documents.superseded_by/at/reason\` columns. The route read from the legacy \`supersede_log\` table — which was no longer being populated. API returned empty/stale lists.

**Fix:** \`GET /api/supersede\` now reads from \`oracle_documents.superseded_by\` as source of truth. Legacy \`supersede_log\` kept for POST backwards-compat.

### 2. \`arra_search\` didn't surface supersede flags

P-001 says superseded docs stay searchable, but callers had no way to know a hit was superseded. The MCP tool's success message claimed \"will appear in searches with a warning\" but none was emitted.

**Fix:** After combining FTS + vector results, enrich each row with \`superseded_by\`, \`superseded_at\`, \`superseded_reason\` from \`oracle_documents\` so UIs can display the replacement pointer.

### 3. \`arra_supersede\` success message

Updated to accurately describe what happens (fields set on the doc, not a warning injected at search time).

## Test plan
- [ ] \`arra_supersede\` call → \`GET /api/supersede?project=X\` shows the new entry
- [ ] \`arra_search\` for a superseded doc → result row carries \`superseded_by\`/\`superseded_at\`/\`superseded_reason\`
- [ ] Legacy \`POST /api/supersede\` still writes to \`supersede_log\` (backwards compat)