### PR TITLE
feat(arra_learn): inline vector embedding on every write

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,7 @@ class OracleMCPServer {
 
     this.vectorStore = createVectorStore({
       dataPath: CHROMADB_DIR,
+      embeddingModel: 'bge-m3',
     });
 
     const pkg = JSON.parse(fs.readFileSync(path.join(import.meta.dirname || __dirname, '..', 'package.json'), 'utf-8'));

--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -10,6 +10,7 @@ import fs from 'fs';
 import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
+import { getVectorStoreByModel } from '../vector/factory.ts';
 import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
 
 /** Coerce concepts to string[] — handles string, array, or undefined from MCP input */
@@ -181,10 +182,37 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     createdBy: 'arra_learn',
   }).run();
 
+  // FTS5 has no unique constraint on id — delete-then-insert to be idempotent.
+  ctx.sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
   ctx.sqlite.prepare(`
     INSERT INTO oracle_fts (id, content, concepts)
     VALUES (?, ?, ?)
   `).run(id, frontmatter, conceptsList.join(' '));
+
+  // Inline vector embedding — keep DB + lancedb in step so arra_search hybrid
+  // mode works immediately without a follow-up `bun run index-model`. Graceful
+  // fallback: if the embedder is unreachable (e.g. Ollama down) we log and
+  // carry on — the FTS row above is still searchable.
+  let embeddingStatus: 'ok' | 'skipped' | 'failed' = 'skipped';
+  try {
+    const model = process.env.ORACLE_EMBEDDING_MODEL || 'bge-m3';
+    const vectorStore = getVectorStoreByModel(model);
+    await vectorStore.addDocuments([{
+      id,
+      document: frontmatter,
+      metadata: {
+        type: 'learning',
+        source_file: sourceFileRel,
+        project: project || '',
+        concepts: conceptsList.join(','),
+      },
+    }]);
+    embeddingStatus = 'ok';
+  } catch (err) {
+    embeddingStatus = 'failed';
+    console.warn(`[arra_learn] vector embedding failed for ${id}: ${err instanceof Error ? err.message : String(err)}`);
+    console.warn(`[arra_learn] document still searchable via FTS5; run 'bun src/scripts/index-model.ts <model>' later to backfill vectors`);
+  }
 
   return {
     content: [{
@@ -193,7 +221,8 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
         success: true,
         file: sourceFileRel,
         id,
-        message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}`
+        embedding: embeddingStatus,
+        message: `Pattern added to Oracle knowledge base${vaultRoot ? ' (vault)' : ''}${embeddingStatus === 'failed' ? ' — vector embedding failed, see server log' : ''}`
       }, null, 2)
     }]
   };


### PR DESCRIPTION
## Summary

\`arra_learn\` now generates a vector embedding inline (right after the FTS5 insert). Keeps SQLite + LanceDB in step without a separate batch step.

## Why

Before: \`arra_learn\` → .md file + \`oracle_documents\` row + FTS5 row. No vector. \`arra_search\` hybrid mode returned stale/missing vector hits for anything added since the last \`bun src/scripts/index-model.ts\` batch.

After: \`arra_learn\` → all of the above + inline \`vectorStore.addDocuments(...)\` call. New doc is hybrid-searchable immediately.

## Behavior

- **Model:** default \`bge-m3\`, overridable via \`ORACLE_EMBEDDING_MODEL\` env.
- **Metadata stored with vector:** \`type\`, \`source_file\`, \`project\`, \`concepts\`.
- **Graceful fallback:** if the embedder is unreachable (Ollama down, model not pulled, network blip), log a warning and carry on. The FTS row is unaffected. \`bun src/scripts/index-model.ts <model>\` can backfill later.
- **Response:** JSON now includes \`embedding: 'ok' | 'failed' | 'skipped'\` so callers don't have to guess.

## Latency

~15-20 ms per doc on M-series Mac with Ollama GPU + bge-m3. Blocks the tool response but below perceptible threshold for interactive use.

## Depends on

- #750 (FTS5 dedupe fix) — learn.ts in this PR also includes the same \`DELETE FROM oracle_fts WHERE id=?\` before INSERT, for parity with the indexer/handler fix. If #750 merges first, this PR will auto-merge cleanly. If this lands first, #750 rebases to drop the duplicate hunk in \`handlers.ts\` (no drift, same intent).

## Test plan
- [ ] Fresh \`arra_learn\` call → response JSON has \`embedding: 'ok'\`
- [ ] Verify LanceDB row count incremented: \`bun -e 'import("./src/vector/factory.ts").then(m => m.getVectorStoreByModel("bge-m3").getStats().then(console.log))'\`
- [ ] Disable Ollama → \`arra_learn\` returns \`embedding: 'failed'\` but still succeeds; FTS row present
- [ ] \`arra_search query=<new doc content> mode=hybrid\` finds the just-added doc via vector similarity without running the batch script