### PR TITLE
docs: agent bootstrap in CLAUDE.md + reindex:full script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,15 @@
-# CLAUDE.md - Generic AI Assistant Guidelines
+# CLAUDE.md - arra-oracle-v3
+
+## Agent Bootstrap
+
+If you are an agent spawned via `maw wake`, do this **before any other work**:
+
+1. Read `.agent/AGENTS.md` — your team charter, safety rules, and memory protocol.
+2. Read your skill manifest at `.agent/skills/<your-role>/SKILL.md` — it contains your identity, workflows, and first-session instructions.
+
+Active agents in this repo: `brew-ops` (`.agent/skills/brew-ops/`).
+
+---
 
 ## Table of Contents
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "vault:pull": "bun src/vault/cli.ts pull",
     "vault:status": "bun src/vault/cli.ts status",
     "vault:migrate": "bun src/vault/cli.ts migrate",
-    "vault:rsync": "./scripts/vault-rsync.sh"
+    "vault:rsync": "./scripts/vault-rsync.sh",
+    "reindex:full": "bun src/indexer/cli.ts && bun src/scripts/index-model.ts bge-m3"
   },
   "dependencies": {
     "@lancedb/lancedb": "^0.26.2",


### PR DESCRIPTION
## Summary

Two small improvements:

### 1. \`CLAUDE.md\` — Agent Bootstrap section

Adds a short section at the top of \`CLAUDE.md\` pointing maw-spawned agents at:

- \`.agent/AGENTS.md\` — team charter, safety rules, memory protocol
- \`.agent/skills/<role>/SKILL.md\` — role identity + workflows + first-session steps

Lists active roles in this repo (\`brew-ops\`).

### 2. \`package.json\` — \`reindex:full\` script

\`\`\`json
\"reindex:full\": \"bun src/indexer/cli.ts && bun src/scripts/index-model.ts bge-m3\"
\`\`\`

Convenience wrapper for full rebuild (SQLite + FTS5 + vectors). Useful after bulk vault imports where inline \`arra_learn\` embedding (#754) wasn't the write path.

## Test plan
- [ ] New agent session reads CLAUDE.md and finds bootstrap link first
- [ ] \`bun run reindex:full\` completes SQLite + vector refresh in sequence