### PR TITLE
feat(cli): plugin loader + universal flags

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,31 +1,63 @@
 #!/usr/bin/env bun
 
+import { join } from "path";
 import { discoverPlugins } from "./plugin/loader.ts";
 import { registerPlugins, resolveCommand, listPlugins } from "./plugin/registry.ts";
 import { invokePlugin } from "./plugin/invoke.ts";
+import type { LoadedPlugin } from "./plugin/types.ts";
 
-const VERSION = "0.0.1";
+const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
+const VERSION: string = pkg.version;
 
 function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log(`neo-arra v${VERSION} — ARRA Oracle V3 CLI\n`);
   console.log("Usage: neo-arra <command> [args...]\n");
   console.log("Commands:");
   for (const { command, help } of commands) {
-    const pad = command.padEnd(16);
-    console.log(`  ${pad}${help ?? ""}`);
+    console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
   console.log("\nFlags:");
-  console.log("  --help, -h    Show this help");
-  console.log("  --version     Show version");
+  console.log("  --help, -h        Show this help");
+  console.log("  -h <command>      Show command help + flags");
+  console.log("  --version         Show version");
+}
+
+function printCommandHelp(plugin: LoadedPlugin) {
+  const cli = plugin.manifest.cli!;
+  console.log(`${cli.command} — ${cli.help ?? "(no description)"}`);
+  if (cli.aliases?.length) {
+    console.log(`  aliases: ${cli.aliases.join(", ")}`);
+  }
+  if (cli.flags && Object.keys(cli.flags).length > 0) {
+    console.log("\nFlags:");
+    for (const [flag, desc] of Object.entries(cli.flags)) {
+      console.log(`  ${flag.padEnd(20)}${desc}`);
+    }
+  } else {
+    console.log("  (no flags)");
+  }
+}
+
+async function loadAll() {
+  const { plugins, bundled, user } = await discoverPlugins();
+  registerPlugins(plugins);
+  const total = bundled + user;
+  const parts: string[] = [`${bundled} bundled`];
+  if (user > 0) parts.push(`${user} user`);
+  console.log(`loaded ${total} plugin${total !== 1 ? "s" : ""} (${parts.join(", ")})`);
 }
 
 async function main() {
   const args = process.argv.slice(2);
   const cmd = args[0]?.toLowerCase();
 
-  if (!cmd || cmd === "--help" || cmd === "-h") {
-    const plugins = await discoverPlugins();
-    registerPlugins(plugins);
+  if (cmd === "--version" || cmd === "version") {
+    console.log(`neo-arra v${VERSION}`);
+    return;
+  }
+
+  if (!cmd || cmd === "--help") {
+    await loadAll();
     const commands = listPlugins()
       .filter(p => p.manifest.cli)
       .map(p => ({ command: p.manifest.cli!.command, help: p.manifest.cli!.help }));
@@ -33,13 +65,26 @@ async function main() {
     return;
   }
 
-  if (cmd === "--version" || cmd === "version") {
-    console.log(`neo-arra v${VERSION}`);
+  if (cmd === "-h") {
+    const subcmd = args[1]?.toLowerCase();
+    await loadAll();
+    if (!subcmd) {
+      const commands = listPlugins()
+        .filter(p => p.manifest.cli)
+        .map(p => ({ command: p.manifest.cli!.command, help: p.manifest.cli!.help }));
+      printHelp(commands);
+      return;
+    }
+    const plugin = resolveCommand(subcmd);
+    if (!plugin || !plugin.manifest.cli) {
+      console.error(`unknown command: ${args[1]}`);
+      process.exit(1);
+    }
+    printCommandHelp(plugin);
     return;
   }
 
-  const plugins = await discoverPlugins();
-  registerPlugins(plugins);
+  await loadAll();
 
   const plugin = resolveCommand(cmd);
   if (!plugin) {

--- a/cli/src/plugin/loader.ts
+++ b/cli/src/plugin/loader.ts
@@ -7,6 +7,12 @@ import type { LoadedPlugin } from "./types.ts";
 const USER_PLUGIN_DIR = join(homedir(), ".neo-arra", "plugins");
 const BUNDLED_PLUGIN_DIR = join(import.meta.dir, "..", "plugins");
 
+export interface DiscoverResult {
+  plugins: LoadedPlugin[];
+  bundled: number;
+  user: number;
+}
+
 async function loadPluginDir(dir: string): Promise<LoadedPlugin | null> {
   const manifestPath = join(dir, "plugin.json");
   if (!existsSync(manifestPath)) return null;
@@ -21,12 +27,14 @@ async function loadPluginDir(dir: string): Promise<LoadedPlugin | null> {
   }
 }
 
-export async function discoverPlugins(): Promise<LoadedPlugin[]> {
+export async function discoverPlugins(): Promise<DiscoverResult> {
   const plugins: LoadedPlugin[] = [];
   const seen = new Set<string>();
+  let bundled = 0;
+  let user = 0;
 
   // user plugins scanned first so they override bundled plugins with the same name
-  for (const baseDir of [USER_PLUGIN_DIR, BUNDLED_PLUGIN_DIR]) {
+  for (const [isUser, baseDir] of [[true, USER_PLUGIN_DIR], [false, BUNDLED_PLUGIN_DIR]] as [boolean, string][]) {
     if (!existsSync(baseDir)) continue;
     const entries = readdirSync(baseDir, { withFileTypes: true });
     for (const entry of entries) {
@@ -34,12 +42,13 @@ export async function discoverPlugins(): Promise<LoadedPlugin[]> {
       const pluginDir = join(baseDir, entry.name);
       const loaded = await loadPluginDir(pluginDir);
       if (!loaded) continue;
-      // user plugins override bundled by same name
       if (seen.has(loaded.manifest.name)) continue;
       seen.add(loaded.manifest.name);
       plugins.push(loaded);
+      if (isUser) user++;
+      else bundled++;
     }
   }
 
-  return plugins;
+  return { plugins, bundled, user };
 }


### PR DESCRIPTION
closes #769

## What
- `cli/src/plugin/loader.ts` — discoverPlugins() scans bundled + user plugins
- `cli/src/cli.ts` — `--version`, `--help`, `-h <cmd>` flags

## Size
70 lines added, 16 removed. Lean ✓.

## Verify
- `bun run src/cli.ts --version` → prints package.json version
- `bun run src/cli.ts --help` → lists bundled commands
- `bun run src/cli.ts hello` → still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)