### PR TITLE
fix(web): import global.css in Base.astro so Tailwind ships

### DIFF
--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -1,4 +1,6 @@
 ---
+import "../styles/global.css";
+
 interface Props {
   title?: string;
 }


### PR DESCRIPTION
follow-up to #790. The adapter removal fixed the deploy, but Tailwind CSS wasn't actually being emitted — @tailwindcss/vite needs an explicit import to trigger bundling.

Fix: add `import '../styles/global.css'` to Base.astro frontmatter.

Verified: dist/_astro/index.CBO0w9xV.css now emitted and linked from HTML. Deployed. https://neo.buildwithoracle.com now styled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)