### PR TITLE
feat(web): canvas plugin loader — 3 demo ESM plugins (cube/galaxy/torus)

### DIFF
--- a/web/public/plugins/cube.mjs
+++ b/web/public/plugins/cube.mjs
@@ -1,0 +1,25 @@
+export default {
+  name: "cube",
+  mount({ scene, THREE }) {
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    const material = new THREE.MeshStandardMaterial({
+      color: 0x7c3aed,
+      roughness: 0.4,
+      metalness: 0.2,
+    });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    return {
+      tick() {
+        cube.rotation.x += 0.01;
+        cube.rotation.y += 0.012;
+      },
+      dispose() {
+        scene.remove(cube);
+        geometry.dispose();
+        material.dispose();
+      },
+    };
+  },
+};

--- a/web/public/plugins/galaxy.mjs
+++ b/web/public/plugins/galaxy.mjs
@@ -1,0 +1,61 @@
+export default {
+  name: "galaxy",
+  mount({ scene, camera, THREE }) {
+    camera.position.z = 6;
+
+    const COUNT = 4000;
+    const positions = new Float32Array(COUNT * 3);
+    const colors = new Float32Array(COUNT * 3);
+    const radii = new Float32Array(COUNT);
+    const palette = [
+      new THREE.Color(0x7c3aed),
+      new THREE.Color(0x22d3ee),
+      new THREE.Color(0xf472b6),
+    ];
+
+    for (let i = 0; i < COUNT; i++) {
+      const r = Math.pow(Math.random(), 0.5) * 4;
+      const branch = (i % 3) * ((2 * Math.PI) / 3);
+      const spin = r * 1.2;
+      const theta = branch + spin + (Math.random() - 0.5) * 0.4;
+      const y = (Math.random() - 0.5) * 0.3 * (1 - r / 4);
+
+      positions[i * 3 + 0] = Math.cos(theta) * r;
+      positions[i * 3 + 1] = y;
+      positions[i * 3 + 2] = Math.sin(theta) * r;
+
+      const c = palette[i % palette.length];
+      colors[i * 3 + 0] = c.r;
+      colors[i * 3 + 1] = c.g;
+      colors[i * 3 + 2] = c.b;
+      radii[i] = r;
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    geometry.setAttribute("color", new THREE.BufferAttribute(colors, 3));
+
+    const material = new THREE.PointsMaterial({
+      size: 0.04,
+      vertexColors: true,
+      transparent: true,
+      opacity: 0.9,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+
+    const points = new THREE.Points(geometry, material);
+    scene.add(points);
+
+    return {
+      tick() {
+        points.rotation.y += 0.0025;
+      },
+      dispose() {
+        scene.remove(points);
+        geometry.dispose();
+        material.dispose();
+      },
+    };
+  },
+};

--- a/web/public/plugins/torus.mjs
+++ b/web/public/plugins/torus.mjs
@@ -1,0 +1,27 @@
+export default {
+  name: "torus",
+  mount({ scene, THREE }) {
+    const geometry = new THREE.TorusKnotGeometry(1, 0.3, 128, 16);
+    const material = new THREE.MeshStandardMaterial({
+      color: 0x22d3ee,
+      roughness: 0.2,
+      metalness: 0.6,
+      emissive: 0x164e63,
+      emissiveIntensity: 0.3,
+    });
+    const knot = new THREE.Mesh(geometry, material);
+    scene.add(knot);
+
+    return {
+      tick() {
+        knot.rotation.x += 0.006;
+        knot.rotation.y += 0.008;
+      },
+      dispose() {
+        scene.remove(knot);
+        geometry.dispose();
+        material.dispose();
+      },
+    };
+  },
+};

--- a/web/src/pages/canvas.astro
+++ b/web/src/pages/canvas.astro
@@ -8,9 +8,17 @@ import Base from "../layouts/Base.astro";
       <a href="/" class="text-gray-500 hover:text-gray-300 text-sm transition-colors">← home</a>
       <h1 class="text-4xl font-bold tracking-tight mt-4 mb-2">Canvas</h1>
       <p class="text-gray-400 text-lg">
-        A Three.js host for Neo ARRA V3 visual plugins. The rotating cube below
-        is a placeholder — future plugins mount onto the same scene.
+        A Three.js host for Neo ARRA V3 visual plugins. Swap the plugin with
+        <code class="text-teal-400">?plugin=&lt;name&gt;</code> — each plugin is
+        an ESM module that exports <code class="text-teal-400">mount()</code>.
       </p>
+    </div>
+
+    <div class="flex gap-2 mb-4 text-sm">
+      <a href="/canvas/?plugin=cube" class="px-3 py-1 rounded bg-gray-800 hover:bg-gray-700 transition-colors">cube</a>
+      <a href="/canvas/?plugin=galaxy" class="px-3 py-1 rounded bg-gray-800 hover:bg-gray-700 transition-colors">galaxy</a>
+      <a href="/canvas/?plugin=torus" class="px-3 py-1 rounded bg-gray-800 hover:bg-gray-700 transition-colors">torus</a>
+      <span id="plugin-label" class="ml-auto text-gray-500"></span>
     </div>
 
     <div id="neo-canvas-wrap" class="w-full h-[70vh] bg-black rounded-lg overflow-hidden">
@@ -21,9 +29,27 @@ import Base from "../layouts/Base.astro";
   <script>
     import * as THREE from "three";
 
+    type PluginInstance = { tick?: () => void; dispose?: () => void };
+    type PluginModule = {
+      default: {
+        name: string;
+        mount: (ctx: {
+          scene: THREE.Scene;
+          camera: THREE.PerspectiveCamera;
+          renderer: THREE.WebGLRenderer;
+          THREE: typeof THREE;
+        }) => PluginInstance;
+      };
+    };
+
     const canvas = document.getElementById("neo-canvas") as HTMLCanvasElement | null;
     const wrap = document.getElementById("neo-canvas-wrap");
+    const label = document.getElementById("plugin-label");
+
     if (canvas && wrap) {
+      const params = new URLSearchParams(location.search);
+      const pluginName = params.get("plugin") ?? "cube";
+
       const scene = new THREE.Scene();
       scene.background = new THREE.Color(0x000000);
 
@@ -32,11 +58,6 @@ import Base from "../layouts/Base.astro";
 
       const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
-
-      const geometry = new THREE.BoxGeometry(1, 1, 1);
-      const material = new THREE.MeshStandardMaterial({ color: 0x7c3aed, roughness: 0.4, metalness: 0.2 });
-      const cube = new THREE.Mesh(geometry, material);
-      scene.add(cube);
 
       const light = new THREE.PointLight(0xffffff, 50, 100);
       light.position.set(3, 3, 5);
@@ -53,27 +74,39 @@ import Base from "../layouts/Base.astro";
         }
       };
       setSize();
-
       const ro = new ResizeObserver(setSize);
       ro.observe(wrap);
 
+      let instance: PluginInstance = {};
       let raf = 0;
       let disposed = false;
-      const tick = () => {
-        if (disposed) return;
-        cube.rotation.x += 0.01;
-        cube.rotation.y += 0.012;
-        renderer.render(scene, camera);
+
+      (async () => {
+        try {
+          const mod: PluginModule = await import(
+            /* @vite-ignore */ `/plugins/${pluginName}.mjs`
+          );
+          instance = mod.default.mount({ scene, camera, renderer, THREE });
+          if (label) label.textContent = `plugin: ${mod.default.name}`;
+        } catch (err) {
+          console.error("plugin load failed:", err);
+          if (label) label.textContent = `error loading '${pluginName}'`;
+        }
+
+        const tick = () => {
+          if (disposed) return;
+          instance.tick?.();
+          renderer.render(scene, camera);
+          raf = requestAnimationFrame(tick);
+        };
         raf = requestAnimationFrame(tick);
-      };
-      raf = requestAnimationFrame(tick);
+      })();
 
       const cleanup = () => {
         disposed = true;
         cancelAnimationFrame(raf);
         ro.disconnect();
-        geometry.dispose();
-        material.dispose();
+        instance.dispose?.();
         renderer.dispose();
       };
       window.addEventListener("beforeunload", cleanup, { once: true });


### PR DESCRIPTION
closes #810 • refs #772

## Plugin contract
```js
export default {
  name: 'galaxy',
  mount({ scene, camera, renderer, THREE }) {
    // add things to scene
    return { tick() {...}, dispose() {...} };
  }
}
```

## Ships 3 plugins
- /canvas/?plugin=cube — purple box (original)
- /canvas/?plugin=galaxy — 4k-point particle galaxy
- /canvas/?plugin=torus — cyan torus knot

Page is 112 lines (under 200 target).