### PR TITLE
bump: v26.4.19-alpha.1 — first CalVer tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "0.5.0",
+  "version": "26.4.19-alpha.1",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Bumps package.json to 26.4.19-alpha.1. Merging triggers Auto Tag workflow (from #824) → creates v26.4.19-alpha.1 tag → triggers Release workflow → GitHub release.