### PR TITLE
feat(cors): PNA header for deployed studio → localhost

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -96,6 +96,16 @@ app.use('*', cors({
   allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
 }));
 
+// Private Network Access (Chrome 117+): allow https origins to reach our
+// http://localhost when they preflight with Access-Control-Request-Private-Network.
+// This lets studio.buildwithoracle.com fetch a user's local MCP at :47778.
+app.use('*', async (c, next) => {
+  if (c.req.header('access-control-request-private-network') === 'true') {
+    c.header('Access-Control-Allow-Private-Network', 'true');
+  }
+  await next();
+});
+
 // Security headers middleware
 app.use('*', async (c, next) => {
   await next();


### PR DESCRIPTION
## Why

`https://studio.buildwithoracle.com` tries to reach the user's local MCP at `http://localhost:47778`. Chrome 117+ requires the server to answer Private Network Access (PNA) preflight with `Access-Control-Allow-Private-Network: true`, otherwise the request is blocked with a CORS error — even if regular CORS is already correct.

## What

10-line middleware after `cors()` — if request has `Access-Control-Request-Private-Network: true`, reply with the allow header. Non-PNA requests unaffected.

## Verify

```
curl -si -X OPTIONS -H "Origin: https://studio.buildwithoracle.com" \
  -H "Access-Control-Request-Private-Network: true" \
  -H "Access-Control-Request-Method: GET" \
  http://localhost:47778/api/health | grep -i private-network
# → Access-Control-Allow-Private-Network: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)