### PR TITLE
feat(api): /api/plugins endpoints for WASM console

### DIFF
--- a/src/routes/plugins.ts
+++ b/src/routes/plugins.ts
@@ -1,0 +1,46 @@
+/**
+ * Plugin Routes — /api/plugins, /api/plugins/:name
+ *
+ * Serves WASM plugins from ~/.oracle/plugins/*.wasm for the studio's
+ * /plugins page. Single-user, local-only — no auth.
+ */
+
+import type { Hono } from 'hono';
+import { readdirSync, statSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
+
+export function registerPluginRoutes(app: Hono) {
+  app.get('/api/plugins', (c) => {
+    if (!existsSync(PLUGIN_DIR)) {
+      return c.json({ plugins: [], dir: PLUGIN_DIR });
+    }
+    const plugins = readdirSync(PLUGIN_DIR)
+      .filter((f) => f.endsWith('.wasm'))
+      .map((file) => {
+        const st = statSync(join(PLUGIN_DIR, file));
+        return {
+          name: file.replace(/\.wasm$/, ''),
+          file,
+          size: st.size,
+          modified: st.mtime.toISOString(),
+        };
+      });
+    return c.json({ plugins, dir: PLUGIN_DIR });
+  });
+
+  app.get('/api/plugins/:name', (c) => {
+    const name = c.req.param('name').replace(/[^\w.-]/g, '');
+    const file = name.endsWith('.wasm') ? name : `${name}.wasm`;
+    const path = join(PLUGIN_DIR, file);
+    if (!existsSync(path)) {
+      return c.json({ error: 'plugin not found', name }, 404);
+    }
+    const bytes = readFileSync(path);
+    return new Response(bytes, {
+      headers: { 'content-type': 'application/wasm' },
+    });
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,7 @@ import { registerKnowledgeRoutes } from './routes/knowledge.ts';
 import { registerSupersedeRoutes } from './routes/supersede.ts';
 import { registerFileRoutes } from './routes/files.ts';
 import { registerOracleNetRoutes } from './routes/oraclenet.ts';
+import { registerPluginRoutes } from './routes/plugins.ts';
 
 // Reset stale indexing status on startup using Drizzle
 try {
@@ -119,6 +120,7 @@ registerKnowledgeRoutes(app);
 registerSupersedeRoutes(app);
 registerFileRoutes(app);
 registerOracleNetRoutes(app);
+registerPluginRoutes(app);
 
 // Startup banner
 console.log(`


### PR DESCRIPTION
## What

- `GET /api/plugins` → `{ plugins: [{ name, file, size, modified }], dir }` from `~/.oracle/plugins/*.wasm`
- `GET /api/plugins/:name` → raw bytes, `content-type: application/wasm`

## Why

Backend for the studio's `/plugins` WASM console page (coming next).

## Safety

Single-user, local-only, no auth (per 2026-04-19 architectural stance). Filename sanitized to `[\w.-]+`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)