### PR TITLE
bump: v26.4.19-alpha.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Phukhao Oracle is landing here: https://phukhao.buildwithoracle.com/presentation
 | | |
 |---|---|
 | **Status** | Always Nightly |
-| **Version** | 26.4.19-alpha.1 |
+| **Version** | 26.4.19-alpha.2 |
 | **Created** | 2025-12-29 |
 | **Updated** | 2026-04-19 |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.4.19-alpha.1",
+  "version": "26.4.19-alpha.2",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Alpha.2: #846 PNA CORS + #847 /api/plugins endpoints. Triggers auto-tag + release.