### PR TITLE
feat(plugins): backend scans nested plugin dirs (#851)

### DIFF
--- a/src/routes/plugins.ts
+++ b/src/routes/plugins.ts
@@ -1,8 +1,12 @@
 /**
  * Plugin Routes — /api/plugins, /api/plugins/:name
  *
- * Serves WASM plugins from ~/.oracle/plugins/*.wasm for the studio's
- * /plugins page. Single-user, local-only — no auth.
+ * Serves WASM plugins from ~/.oracle/plugins/ for the studio's /plugins page.
+ * Single-user, local-only — no auth.
+ *
+ * Supports two layouts side-by-side:
+ *   1. Nested:  ~/.oracle/plugins/<name>/plugin.json + <wasm-from-manifest>
+ *   2. Flat:    ~/.oracle/plugins/<name>.wasm
  */
 
 import type { Hono } from 'hono';
@@ -12,30 +16,98 @@ import { homedir } from 'os';
 
 const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
 
+type PluginEntry = {
+  name: string;
+  file: string;
+  size: number;
+  modified: string;
+  version?: string;
+  description?: string;
+};
+
+function readNestedPlugin(dir: string, entryName: string): PluginEntry | null {
+  const manifestPath = join(dir, 'plugin.json');
+  if (!existsSync(manifestPath)) return null;
+  let manifest: { name?: string; version?: string; description?: string; wasm?: string };
+  try {
+    manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  } catch {
+    return null;
+  }
+  const wasmName = manifest.wasm;
+  if (!wasmName || typeof wasmName !== 'string') return null;
+  const wasmPath = join(dir, wasmName);
+  if (!existsSync(wasmPath)) return null;
+  const st = statSync(wasmPath);
+  return {
+    name: typeof manifest.name === 'string' && manifest.name ? manifest.name : entryName,
+    file: wasmName,
+    size: st.size,
+    modified: st.mtime.toISOString(),
+    version: typeof manifest.version === 'string' ? manifest.version : undefined,
+    description: typeof manifest.description === 'string' ? manifest.description : undefined,
+  };
+}
+
+function readFlatPlugin(file: string): PluginEntry {
+  const st = statSync(join(PLUGIN_DIR, file));
+  return {
+    name: file.replace(/\.wasm$/, ''),
+    file,
+    size: st.size,
+    modified: st.mtime.toISOString(),
+  };
+}
+
+function resolveWasmPath(name: string): string | null {
+  const nestedManifest = join(PLUGIN_DIR, name, 'plugin.json');
+  if (existsSync(nestedManifest)) {
+    try {
+      const manifest = JSON.parse(readFileSync(nestedManifest, 'utf8'));
+      if (manifest.wasm && typeof manifest.wasm === 'string') {
+        const p = join(PLUGIN_DIR, name, manifest.wasm);
+        if (existsSync(p)) return p;
+      }
+    } catch {
+      // fall through to flat
+    }
+  }
+  const flat = join(PLUGIN_DIR, `${name}.wasm`);
+  if (existsSync(flat)) return flat;
+  return null;
+}
+
 export function registerPluginRoutes(app: Hono) {
   app.get('/api/plugins', (c) => {
     if (!existsSync(PLUGIN_DIR)) {
       return c.json({ plugins: [], dir: PLUGIN_DIR });
     }
-    const plugins = readdirSync(PLUGIN_DIR)
-      .filter((f) => f.endsWith('.wasm'))
-      .map((file) => {
-        const st = statSync(join(PLUGIN_DIR, file));
-        return {
-          name: file.replace(/\.wasm$/, ''),
-          file,
-          size: st.size,
-          modified: st.mtime.toISOString(),
-        };
-      });
+    const plugins: PluginEntry[] = [];
+    for (const entry of readdirSync(PLUGIN_DIR)) {
+      const fullPath = join(PLUGIN_DIR, entry);
+      let st;
+      try {
+        st = statSync(fullPath);
+      } catch {
+        continue;
+      }
+      if (st.isDirectory()) {
+        const nested = readNestedPlugin(fullPath, entry);
+        if (nested) plugins.push(nested);
+      } else if (st.isFile() && entry.endsWith('.wasm')) {
+        plugins.push(readFlatPlugin(entry));
+      }
+    }
     return c.json({ plugins, dir: PLUGIN_DIR });
   });
 
   app.get('/api/plugins/:name', (c) => {
-    const name = c.req.param('name').replace(/[^\w.-]/g, '');
-    const file = name.endsWith('.wasm') ? name : `${name}.wasm`;
-    const path = join(PLUGIN_DIR, file);
-    if (!existsSync(path)) {
+    const name = c.req.param('name').replace(/[^\w.-]/g, '').replace(/\.wasm$/, '');
+    if (!name) {
+      return c.json({ error: 'invalid plugin name' }, 400);
+    }
+    const path = resolveWasmPath(name);
+    if (!path) {
       return c.json({ error: 'plugin not found', name }, 404);
     }
     const bytes = readFileSync(path);


### PR DESCRIPTION
Closes #851

## Summary
- `GET /api/plugins` now scans both nested (`<name>/plugin.json` + wasm) and flat (`<name>.wasm`) layouts
- List response includes `{name, file, size, modified, version?, description?}` — manifest fields surface when present
- `GET /api/plugins/:name` resolves nested first, falls back to flat, 404 otherwise
- `:name` sanitized to `[\w.-]+` (strips traversal attempts)
- Backward compatible — existing flat demo/hello plugins keep working

## Verified
Ran inline Hono request against real `~/.oracle/plugins/` with a fixture of both layouts:
- Nested `arra-hello` (128B) → listed with `version: "0.1.0"`, `description: "test plugin"`; GET returns 200 + `application/wasm` 128B
- Flat `legacy.wasm` (64B) → listed plainly; GET returns 200 + `application/wasm` 64B
- Missing name → 404
- Traversal attempt (`..%2F..%2Fetc%2Fpasswd`) → 404 after sanitization

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle