### PR TITLE
refactor(cli): rename neo-arra → arra-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Distributed via GitHub — no npm publish needed:
 bunx --bun arra-oracle@github:Soul-Brews-Studio/arra-oracle-v3
 
 # CLI (plugin runner)
-bunx --bun neo-arra@github:Soul-Brews-Studio/arra-oracle-v3 --help
+bunx --bun arra-cli@github:Soul-Brews-Studio/arra-oracle-v3 --help
 
 # UI (dashboard — separate repo)
 bunx --bun oracle-studio@github:Soul-Brews-Studio/oracle-studio

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,7 +1,7 @@
-# neo-arra CLI
+# arra-cli CLI
 
-`neo-arra` is the command-line interface for ARRA Oracle V3 — a plugin-based CLI that wraps the arra-oracle-v3 MCP tools (`arra_search`, `arra_learn`, `arra_list`, `arra_trace`, and more) so humans can call them directly from the shell. Plugins live in `src/plugins/` (bundled) or `~/.neo-arra/plugins/` (user-installed), each providing a `plugin.json` manifest and a default-export handler.
+`arra-cli` is the command-line interface for ARRA Oracle V3 — a plugin-based CLI that wraps the arra-oracle-v3 MCP tools (`arra_search`, `arra_learn`, `arra_list`, `arra_trace`, and more) so humans can call them directly from the shell. Plugins live in `src/plugins/` (bundled) or `~/.neo-arra/plugins/` (user-installed), each providing a `plugin.json` manifest and a default-export handler.
 
 ```
-neo-arra --help
+arra-cli --help
 ```

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "neo-arra",
+  "name": "arra-cli",
   "version": "0.0.1",
   "type": "module",
   "bin": {
-    "neo-arra": "./src/cli.ts"
+    "arra-cli": "./src/cli.ts"
   },
   "scripts": {
     "dev": "bun run src/cli.ts",
-    "build": "bun build src/cli.ts --outfile dist/neo-arra --target=bun --minify",
+    "build": "bun build src/cli.ts --outfile dist/arra-cli --target=bun --minify",
     "test": "bun test"
   },
   "engines": {

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -13,8 +13,8 @@ const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
 
 function printHelp(commands: Array<{ command: string; help?: string }>) {
-  console.log(`neo-arra v${VERSION} — ARRA Oracle V3 CLI\n`);
-  console.log("Usage: neo-arra <command> [args...]\n");
+  console.log(`arra-cli v${VERSION} — ARRA Oracle V3 CLI\n`);
+  console.log("Usage: arra-cli <command> [args...]\n");
   console.log("Commands:");
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
   for (const { command, help } of commands) {
@@ -56,7 +56,7 @@ async function main() {
   const cmd = args[0]?.toLowerCase();
 
   if (cmd === "--version" || cmd === "version") {
-    console.log(`neo-arra v${VERSION}`);
+    console.log(`arra-cli v${VERSION}`);
     return;
   }
 
@@ -68,13 +68,13 @@ async function main() {
       process.exit(code);
     }
     if (!sub || sub === "--help" || sub === "-h") {
-      console.log("neo-arra plugin <subcommand>\n");
+      console.log("arra-cli plugin <subcommand>\n");
       console.log("Subcommands:");
       console.log("  install <url-or-path>   install a plugin (see --help)");
       return;
     }
     console.error(`\x1b[31m✗\x1b[0m unknown plugin subcommand: ${args[1]}`);
-    console.error("  try: neo-arra plugin install <url-or-path>");
+    console.error("  try: arra-cli plugin install <url-or-path>");
     process.exit(1);
   }
 
@@ -125,7 +125,7 @@ async function main() {
   const plugin = resolveCommand(cmd);
   if (!plugin) {
     console.error(`\x1b[31m✗\x1b[0m unknown command: ${args[0]}`);
-    console.error(`  run 'neo-arra --help' to see available commands`);
+    console.error(`  run 'arra-cli --help' to see available commands`);
     process.exit(1);
   }
 

--- a/cli/src/commands/plugins-info.ts
+++ b/cli/src/commands/plugins-info.ts
@@ -30,7 +30,7 @@ async function printWasmExports(wasmPath: string): Promise<void> {
 export async function pluginsInfo(args: string[]): Promise<number> {
   const name = args.find(a => !a.startsWith("-"));
   if (!name) {
-    console.error("usage: neo-arra plugin info <name>");
+    console.error("usage: arra-cli plugin info <name>");
     return 1;
   }
 

--- a/cli/src/commands/plugins-install.ts
+++ b/cli/src/commands/plugins-install.ts
@@ -274,14 +274,14 @@ export async function doInstall(
   }
   if (!source) {
     throw new Error(
-      "missing <url-or-path>; see 'neo-arra plugin install --help'",
+      "missing <url-or-path>; see 'arra-cli plugin install --help'",
     );
   }
   await installFromSource(source, opts);
 }
 
 export function printInstallHelp(): void {
-  console.log("neo-arra plugin install <url-or-path> [flags]");
+  console.log("arra-cli plugin install <url-or-path> [flags]");
   console.log("");
   console.log("Sources:");
   console.log("  https://github.com/owner/repo");

--- a/cli/src/commands/plugins-remove.ts
+++ b/cli/src/commands/plugins-remove.ts
@@ -18,7 +18,7 @@ export async function pluginsRemove(args: string[]): Promise<number> {
   const name = args.find(a => !a.startsWith("-"));
 
   if (!name) {
-    console.error("usage: neo-arra plugin remove <name> [--yes]");
+    console.error("usage: arra-cli plugin remove <name> [--yes]");
     return 1;
   }
 

--- a/cli/src/lib/api.ts
+++ b/cli/src/lib/api.ts
@@ -1,9 +1,9 @@
 /**
- * ARRA Oracle HTTP API helper for neo-arra plugins.
+ * ARRA Oracle HTTP API helper for arra-cli plugins.
  *
  * Reads NEO_ARRA_API env (default http://localhost:47778).
  * Note: issue #770 spec listed 3457 — real oracle default is 47778 (ORACLE_DEFAULT_PORT).
- * Override: NEO_ARRA_API=http://localhost:47778 neo-arra <cmd>
+ * Override: NEO_ARRA_API=http://localhost:47778 arra-cli <cmd>
  */
 
 export const BASE_URL = (process.env.NEO_ARRA_API ?? "http://localhost:47778").replace(/\/$/, "");

--- a/cli/src/plugins/hello/index.ts
+++ b/cli/src/plugins/hello/index.ts
@@ -1,6 +1,6 @@
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
 
 export default async function handler(_ctx: InvokeContext): Promise<InvokeResult> {
-  console.log("Hello from neo-arra plugin hello!");
+  console.log("Hello from arra-cli plugin hello!");
   return { ok: true };
 }

--- a/cli/src/plugins/hello/plugin.json
+++ b/cli/src/plugins/hello/plugin.json
@@ -5,6 +5,6 @@
   "sdk": "^0.0.1",
   "cli": {
     "command": "hello",
-    "help": "neo-arra hello — sample plugin"
+    "help": "arra-cli hello — sample plugin"
   }
 }

--- a/cli/src/plugins/learn/index.ts
+++ b/cli/src/plugins/learn/index.ts
@@ -1,4 +1,4 @@
-// neo-arra learn "<pattern>" [--concepts a,b] [--source s]
+// arra-cli learn "<pattern>" [--concepts a,b] [--source s]
 // Calls: POST /api/learn { pattern, concepts?, source? }
 // Note: issue #770 listed this as POST /api/arra_learn — using actual POST /api/learn route
 
@@ -23,7 +23,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 
   if (!pattern) {
-    return { ok: false, error: 'Usage: neo-arra learn "<pattern>" [--concepts a,b] [--source s]' };
+    return { ok: false, error: 'Usage: arra-cli learn "<pattern>" [--concepts a,b] [--source s]' };
   }
 
   const body: Record<string, unknown> = { pattern };

--- a/cli/src/plugins/learn/plugin.json
+++ b/cli/src/plugins/learn/plugin.json
@@ -7,7 +7,7 @@
   "description": "Add a new pattern or learning to ARRA Oracle",
   "cli": {
     "command": "learn",
-    "help": "neo-arra learn \"<pattern>\" [--concepts a,b] [--source s]",
+    "help": "arra-cli learn \"<pattern>\" [--concepts a,b] [--source s]",
     "flags": {
       "--concepts": "Comma-separated concept tags",
       "--source": "Source file or context label"

--- a/cli/src/plugins/list/index.ts
+++ b/cli/src/plugins/list/index.ts
@@ -1,4 +1,4 @@
-// neo-arra list [--type X] [--limit N]
+// arra-cli list [--type X] [--limit N]
 // Calls: GET /api/list?type=X&limit=N
 // Note: issue #770 listed this as /api/arra_list — using actual GET /api/list route
 

--- a/cli/src/plugins/list/plugin.json
+++ b/cli/src/plugins/list/plugin.json
@@ -7,7 +7,7 @@
   "description": "Browse all documents in ARRA Oracle",
   "cli": {
     "command": "list",
-    "help": "neo-arra list [--type X] [--limit N]",
+    "help": "arra-cli list [--type X] [--limit N]",
     "flags": {
       "--type": "Filter: principle|pattern|learning|retro|all (default: all)",
       "--limit": "Max results (default: 20)"

--- a/cli/src/plugins/plugin/index.ts
+++ b/cli/src/plugins/plugin/index.ts
@@ -7,9 +7,9 @@ import { createHash } from "crypto";
 
 const USER_PLUGIN_DIR = join(homedir(), ".neo-arra", "plugins");
 
-const USAGE = `neo-arra plugin — manage plugins
+const USAGE = `arra-cli plugin — manage plugins
 
-Usage: neo-arra plugin <subcommand> [args]
+Usage: arra-cli plugin <subcommand> [args]
 
 Subcommands:
   init <name>             Scaffold a new plugin in ~/.neo-arra/plugins/<name>/
@@ -19,7 +19,7 @@ Subcommands:
   remove <name>           Archive then remove user plugin (Principle 1: Nothing is Deleted)`;
 
 async function cmdInit(name: string): Promise<InvokeResult> {
-  if (!name) return { ok: false, error: "usage: neo-arra plugin init <name>" };
+  if (!name) return { ok: false, error: "usage: arra-cli plugin init <name>" };
   if (!/^[a-z0-9-]+$/.test(name)) {
     return { ok: false, error: `plugin name must match /^[a-z0-9-]+$/, got: ${JSON.stringify(name)}` };
   }
@@ -63,7 +63,7 @@ async function cmdList(): Promise<InvokeResult> {
 async function cmdInstall(args: string[]): Promise<InvokeResult> {
   const link = args.includes("--link");
   const pathArg = args.find(a => !a.startsWith("--"));
-  if (!pathArg) return { ok: false, error: "usage: neo-arra plugin install <path> [--link]" };
+  if (!pathArg) return { ok: false, error: "usage: arra-cli plugin install <path> [--link]" };
 
   const src = resolve(pathArg);
   if (!existsSync(src)) {
@@ -120,14 +120,14 @@ async function cmdBuild(pathArg: string): Promise<InvokeResult> {
 }
 
 async function cmdRemove(name: string): Promise<InvokeResult> {
-  if (!name) return { ok: false, error: "usage: neo-arra plugin remove <name>" };
+  if (!name) return { ok: false, error: "usage: arra-cli plugin remove <name>" };
   const dir = join(USER_PLUGIN_DIR, name);
   if (!existsSync(dir)) {
     return { ok: false, error: `plugin '${name}' not found in ${USER_PLUGIN_DIR}` };
   }
 
   // Principle 1: Nothing is Deleted — archive to /tmp before removing
-  const archive = `/tmp/neo-arra-removed-${name}-${Date.now()}`;
+  const archive = `/tmp/arra-cli-removed-${name}-${Date.now()}`;
   cpSync(dir, archive, { recursive: true });
   rmSync(dir, { recursive: true, force: true });
 

--- a/cli/src/plugins/read/index.ts
+++ b/cli/src/plugins/read/index.ts
@@ -1,4 +1,4 @@
-// neo-arra read <id-or-path>
+// arra-cli read <id-or-path>
 // Calls: GET /api/read?id=<id>  — when arg has no path separators
 //        GET /api/read?file=<path> — when arg looks like a file path
 // Note: issue #770 listed this as /api/arra_read — using actual GET /api/read route
@@ -10,7 +10,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   const target = ctx.args.find(a => !a.startsWith("--"));
 
   if (!target) {
-    return { ok: false, error: "Usage: neo-arra read <id-or-path>" };
+    return { ok: false, error: "Usage: arra-cli read <id-or-path>" };
   }
 
   // Treat as file path if it contains / or . (looks like a path), otherwise as id

--- a/cli/src/plugins/read/plugin.json
+++ b/cli/src/plugins/read/plugin.json
@@ -7,7 +7,7 @@
   "description": "Read a full document from ARRA Oracle by ID or file path",
   "cli": {
     "command": "read",
-    "help": "neo-arra read <id-or-path>",
+    "help": "arra-cli read <id-or-path>",
     "flags": {}
   }
 }

--- a/cli/src/plugins/reflect/index.ts
+++ b/cli/src/plugins/reflect/index.ts
@@ -1,4 +1,4 @@
-// neo-arra reflect [--json]
+// arra-cli reflect [--json]
 // Calls: GET /api/reflect — returns a random wisdom fragment
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/reflect/plugin.json
+++ b/cli/src/plugins/reflect/plugin.json
@@ -7,7 +7,7 @@
   "description": "Get a random reflection / wisdom from the Oracle",
   "cli": {
     "command": "reflect",
-    "help": "neo-arra reflect [--json]",
+    "help": "arra-cli reflect [--json]",
     "flags": {
       "--json": "Output raw JSON instead of formatted reflection"
     }

--- a/cli/src/plugins/schedule/index.ts
+++ b/cli/src/plugins/schedule/index.ts
@@ -1,4 +1,4 @@
-// neo-arra schedule [--date YYYY-MM-DD] [--from X] [--to Y] [--status S] [--limit N]
+// arra-cli schedule [--date YYYY-MM-DD] [--from X] [--to Y] [--status S] [--limit N]
 // Calls: GET /api/schedule?date=...&from=...&to=...&filter=...&status=...&limit=N
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/schedule/plugin.json
+++ b/cli/src/plugins/schedule/plugin.json
@@ -7,7 +7,7 @@
   "description": "List scheduled events",
   "cli": {
     "command": "schedule",
-    "help": "neo-arra schedule [--date YYYY-MM-DD] [--from X] [--to Y] [--status S] [--limit N]",
+    "help": "arra-cli schedule [--date YYYY-MM-DD] [--from X] [--to Y] [--status S] [--limit N]",
     "flags": {
       "--date": "Filter by specific date (YYYY-MM-DD)",
       "--from": "Range start date",

--- a/cli/src/plugins/search/index.ts
+++ b/cli/src/plugins/search/index.ts
@@ -1,4 +1,4 @@
-// neo-arra search "<q>" [--limit N] [--type X]
+// arra-cli search "<q>" [--limit N] [--type X]
 // Calls: GET /api/search?q=<q>&limit=N&type=X
 // Note: issue #770 listed this as POST /api/arra_search — using actual GET /api/search route
 
@@ -23,7 +23,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 
   if (!query) {
-    return { ok: false, error: 'Usage: neo-arra search "<query>" [--limit N] [--type X]' };
+    return { ok: false, error: 'Usage: arra-cli search "<query>" [--limit N] [--type X]' };
   }
 
   const params = new URLSearchParams({ q: query, limit: String(limit), type });

--- a/cli/src/plugins/search/plugin.json
+++ b/cli/src/plugins/search/plugin.json
@@ -7,7 +7,7 @@
   "description": "Search the ARRA Oracle knowledge base",
   "cli": {
     "command": "search",
-    "help": "neo-arra search \"<query>\" [--limit N] [--type X]",
+    "help": "arra-cli search \"<query>\" [--limit N] [--type X]",
     "flags": {
       "--limit": "Max results (default: 10)",
       "--type": "Filter: principle|pattern|learning|retro|all (default: all)"

--- a/cli/src/plugins/stats/index.ts
+++ b/cli/src/plugins/stats/index.ts
@@ -1,4 +1,4 @@
-// neo-arra stats [--json]
+// arra-cli stats [--json]
 // Calls: GET /api/stats
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/stats/plugin.json
+++ b/cli/src/plugins/stats/plugin.json
@@ -7,7 +7,7 @@
   "description": "Show ARRA Oracle database statistics",
   "cli": {
     "command": "stats",
-    "help": "neo-arra stats [--json]",
+    "help": "arra-cli stats [--json]",
     "flags": {
       "--json": "Output raw JSON instead of summary"
     }

--- a/cli/src/plugins/supersede-chain/index.ts
+++ b/cli/src/plugins/supersede-chain/index.ts
@@ -1,4 +1,4 @@
-// neo-arra supersede-chain <path>
+// arra-cli supersede-chain <path>
 // Calls: GET /api/supersede/chain/:path
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
@@ -9,7 +9,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   const docPath = args.find(a => !a.startsWith("--"));
   if (!docPath) {
-    return { ok: false, error: "Usage: neo-arra supersede-chain <path>" };
+    return { ok: false, error: "Usage: arra-cli supersede-chain <path>" };
   }
 
   const res = await apiFetch(`/api/supersede/chain/${encodeURIComponent(docPath)}`);

--- a/cli/src/plugins/supersede-chain/plugin.json
+++ b/cli/src/plugins/supersede-chain/plugin.json
@@ -7,7 +7,7 @@
   "description": "Show supersede chain for a document",
   "cli": {
     "command": "supersede-chain",
-    "help": "neo-arra supersede-chain <path>",
+    "help": "arra-cli supersede-chain <path>",
     "flags": {}
   }
 }

--- a/cli/src/plugins/supersede-list/index.ts
+++ b/cli/src/plugins/supersede-list/index.ts
@@ -1,4 +1,4 @@
-// neo-arra supersede-list [--project X] [--limit N] [--offset N]
+// arra-cli supersede-list [--project X] [--limit N] [--offset N]
 // Calls: GET /api/supersede?project=X&limit=N&offset=N
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/supersede-list/plugin.json
+++ b/cli/src/plugins/supersede-list/plugin.json
@@ -7,7 +7,7 @@
   "description": "List supersession log entries",
   "cli": {
     "command": "supersede-list",
-    "help": "neo-arra supersede-list [--project X] [--limit N] [--offset N]",
+    "help": "arra-cli supersede-list [--project X] [--limit N] [--offset N]",
     "flags": {
       "--project": "Filter by project name",
       "--limit": "Max results (default: 50)",

--- a/cli/src/plugins/thread/index.ts
+++ b/cli/src/plugins/thread/index.ts
@@ -1,4 +1,4 @@
-// neo-arra thread <id>
+// arra-cli thread <id>
 // Calls: GET /api/thread/:id
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
@@ -9,7 +9,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   const id = args.find((a) => !a.startsWith("--"));
 
   if (!id) {
-    return { ok: false, error: "Usage: neo-arra thread <id>" };
+    return { ok: false, error: "Usage: arra-cli thread <id>" };
   }
 
   const res = await apiFetch(`/api/thread/${encodeURIComponent(id)}`);

--- a/cli/src/plugins/thread/plugin.json
+++ b/cli/src/plugins/thread/plugin.json
@@ -7,7 +7,7 @@
   "description": "Show a single forum thread with messages",
   "cli": {
     "command": "thread",
-    "help": "neo-arra thread <id>",
+    "help": "arra-cli thread <id>",
     "flags": {}
   }
 }

--- a/cli/src/plugins/threads/index.ts
+++ b/cli/src/plugins/threads/index.ts
@@ -1,4 +1,4 @@
-// neo-arra threads [--status X] [--limit N] [--offset N]
+// arra-cli threads [--status X] [--limit N] [--offset N]
 // Calls: GET /api/threads?status=X&limit=N&offset=N
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/threads/plugin.json
+++ b/cli/src/plugins/threads/plugin.json
@@ -7,7 +7,7 @@
   "description": "List forum threads in ARRA Oracle",
   "cli": {
     "command": "threads",
-    "help": "neo-arra threads [--status X] [--limit N] [--offset N]",
+    "help": "arra-cli threads [--status X] [--limit N] [--offset N]",
     "flags": {
       "--status": "Filter by status (e.g. open|closed)",
       "--limit": "Max results (default: 20)",

--- a/cli/src/plugins/trace-chain/index.ts
+++ b/cli/src/plugins/trace-chain/index.ts
@@ -1,4 +1,4 @@
-// neo-arra trace-chain <id> [--direction up|down|both]
+// arra-cli trace-chain <id> [--direction up|down|both]
 // Calls: GET /api/traces/:id/chain?direction=...
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
@@ -18,7 +18,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 
   if (!id) {
-    return { ok: false, error: "Usage: neo-arra trace-chain <id> [--direction up|down|both]" };
+    return { ok: false, error: "Usage: arra-cli trace-chain <id> [--direction up|down|both]" };
   }
 
   const params = new URLSearchParams({ direction });

--- a/cli/src/plugins/trace-chain/plugin.json
+++ b/cli/src/plugins/trace-chain/plugin.json
@@ -7,7 +7,7 @@
   "description": "Show the chain (up/down/both) for a trace",
   "cli": {
     "command": "trace-chain",
-    "help": "neo-arra trace-chain <id> [--direction up|down|both]",
+    "help": "arra-cli trace-chain <id> [--direction up|down|both]",
     "flags": {
       "--direction": "Chain direction: up|down|both (default: both)"
     }

--- a/cli/src/plugins/trace-get/index.ts
+++ b/cli/src/plugins/trace-get/index.ts
@@ -1,4 +1,4 @@
-// neo-arra trace-get <id>
+// arra-cli trace-get <id>
 // Calls: GET /api/traces/:id
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
@@ -9,7 +9,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   const id = args.find((a) => !a.startsWith("--"));
 
   if (!id) {
-    return { ok: false, error: "Usage: neo-arra trace-get <id>" };
+    return { ok: false, error: "Usage: arra-cli trace-get <id>" };
   }
 
   const res = await apiFetch(`/api/traces/${encodeURIComponent(id)}`);

--- a/cli/src/plugins/trace-get/plugin.json
+++ b/cli/src/plugins/trace-get/plugin.json
@@ -7,7 +7,7 @@
   "description": "Show a single trace by ID",
   "cli": {
     "command": "trace-get",
-    "help": "neo-arra trace-get <id>",
+    "help": "arra-cli trace-get <id>",
     "flags": {}
   }
 }

--- a/cli/src/plugins/trace-list/index.ts
+++ b/cli/src/plugins/trace-list/index.ts
@@ -1,4 +1,4 @@
-// neo-arra trace-list [--query Q] [--status X] [--project P] [--limit N] [--offset N]
+// arra-cli trace-list [--query Q] [--status X] [--project P] [--limit N] [--offset N]
 // Calls: GET /api/traces?query=&status=&project=&limit=&offset=
 
 import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";

--- a/cli/src/plugins/trace-list/plugin.json
+++ b/cli/src/plugins/trace-list/plugin.json
@@ -7,7 +7,7 @@
   "description": "List traces with filters (status, project, query)",
   "cli": {
     "command": "trace-list",
-    "help": "neo-arra trace-list [--query Q] [--status X] [--project P] [--limit N] [--offset N]",
+    "help": "arra-cli trace-list [--query Q] [--status X] [--project P] [--limit N] [--offset N]",
     "flags": {
       "--query": "Text query to match",
       "--status": "Filter: raw|reviewed|distilled",

--- a/cli/src/plugins/trace/index.ts
+++ b/cli/src/plugins/trace/index.ts
@@ -1,4 +1,4 @@
-// neo-arra trace [query] [--limit N]
+// arra-cli trace [query] [--limit N]
 // Calls: GET /api/traces?query=<query>&limit=N
 // Note: issue #770 listed this as /api/arra_trace — using GET /api/traces (list/search).
 // There is no HTTP POST endpoint to create traces; use the MCP tool arra_trace for that.

--- a/cli/src/plugins/trace/plugin.json
+++ b/cli/src/plugins/trace/plugin.json
@@ -7,7 +7,7 @@
   "description": "List or search discovery traces in ARRA Oracle",
   "cli": {
     "command": "trace",
-    "help": "neo-arra trace [query] [--limit N]",
+    "help": "arra-cli trace [query] [--limit N]",
     "flags": {
       "--limit": "Max results (default: 20)"
     }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bin": {
     "arra-oracle-v3": "./bin/arra.ts",
     "arra-oracle-v2": "./src/index.ts",
-    "neo-arra": "./cli/src/cli.ts"
+    "arra-cli": "./cli/src/cli.ts"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary

Renames the CLI binary and all user-facing help text / error messages / README snippets from `neo-arra` to `arra-cli`, per follow-up naming decision after the plugin-install PR (#857) and list/remove/info PR (#856) landed.

- Root + `cli/package.json` bin entries
- `cli.ts` header, usage line, error messages, version line
- Every bundled plugin's `cli.help` manifest string + in-code usage strings
- `commands/plugins-{install,remove,info}.ts` user-facing strings
- `lib/api.ts` doc comments
- `README.md`, `cli/README.md` snippets

### Deliberately preserved

- `~/.neo-arra/plugins` filesystem path (user plugin home) — renaming would break existing installs; this is a separate concern from the binary name.
- `NEO_ARRA_API` env var — public interface, renaming would break user configs. Can be renamed in a separate PR if desired.

### Invocation after merge

```
bunx --bun arra-cli@github:Soul-Brews-Studio/arra-oracle-v3 plugin install ...
```

## Test plan

- [x] `bun run cli/src/cli.ts --version` → `arra-cli v0.0.1`
- [x] `bun run cli/src/cli.ts plugin install --help` shows `arra-cli` in header
- [x] `grep -rn "neo-arra" cli/ package.json README.md` returns only filesystem path (`~/.neo-arra/`) and env var (`NEO_ARRA_API`) references

🤖 Generated with [Claude Code](https://claude.com/claude-code)