### PR TITLE
bump: v26.4.19-alpha.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Phukhao Oracle is landing here: https://phukhao.buildwithoracle.com/presentation
 | | |
 |---|---|
 | **Status** | Always Nightly |
-| **Version** | 26.4.19-alpha.2 |
+| **Version** | 26.4.19-alpha.3 |
 | **Created** | 2025-12-29 |
 | **Updated** | 2026-04-19 |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.4.19-alpha.2",
+  "version": "26.4.19-alpha.3",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Rolls up today's plugin system work. See commit for the list. Triggers auto-tag + release.yml.