### PR TITLE
feat(release): CalVer hour scheme — calver.ts + ship-alpha.sh (from family)

### DIFF
--- a/scripts/calver.ts
+++ b/scripts/calver.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env bun
+// CalVer bump for arra-oracle-skills-cli
+//
+// Scheme: v{yy}.{m}.{d}[-alpha.{hour}]
+// Spec:   ψ/inbox/2026-04-18_proposal-calver-skills-cli.md (mawjs-oracle)
+//
+// Max 24 alphas per day (one per hour). Stable = no alpha suffix.
+// Timezone comes from the shell — set TZ=Asia/Bangkok in CI if needed.
+//
+// Usage:
+//   bun scripts/calver.ts                  → 26.4.18-alpha.10
+//   bun scripts/calver.ts --stable         → 26.4.18
+//   bun scripts/calver.ts --hour 14        → 26.4.18-alpha.14
+//   bun scripts/calver.ts --check          → dry-run (no writes)
+
+import { $ } from "bun";
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+type Args = { stable: boolean; hour?: number; check: boolean; now?: Date };
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { stable: false, check: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--stable") args.stable = true;
+    else if (a === "--check" || a === "--dry-run") args.check = true;
+    else if (a === "--hour") args.hour = parseInt(argv[++i], 10);
+    else if (a === "-h" || a === "--help") {
+      console.log(HELP);
+      process.exit(0);
+    } else {
+      console.error(`unknown arg: ${a}`);
+      console.error(HELP);
+      process.exit(2);
+    }
+  }
+  return args;
+}
+
+const HELP = `Usage: bun scripts/calver.ts [options]
+
+Compute next CalVer version and bump package.json.
+
+Options:
+  --stable         Cut stable (no alpha suffix)
+  --hour N         Override hour 0-23 (default: current hour)
+  --check          Dry-run: print target, don't modify files
+  -h, --help       Show help
+
+Examples:
+  bun scripts/calver.ts                  alpha at current hour → 26.4.18-alpha.10
+  bun scripts/calver.ts --stable         stable cut            → 26.4.18
+  bun scripts/calver.ts --hour 14        alpha at 14:xx        → 26.4.18-alpha.14
+  bun scripts/calver.ts --check          print only, no write`;
+
+export function computeVersion(args: Args): string {
+  const now = args.now ?? new Date();
+  const yy = now.getFullYear() % 100;
+  const m = now.getMonth() + 1;
+  const d = now.getDate();
+  const base = `${yy}.${m}.${d}`;
+  if (args.stable) return base;
+  const hour = args.hour ?? now.getHours();
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) {
+    throw new Error(`invalid hour: ${hour} (must be 0-23)`);
+  }
+  return `${base}-alpha.${hour}`;
+}
+
+async function tagExists(version: string): Promise<boolean> {
+  const res = await $`git rev-parse --verify --quiet v${version}`.nothrow().quiet();
+  return res.exitCode === 0;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const version = computeVersion(args);
+  const channel = args.stable ? "stable" : "alpha";
+
+  console.log(`Target: v${version}  [${channel}]`);
+
+  if (args.check) {
+    console.log("(check mode — no changes written)");
+    return;
+  }
+
+  if (await tagExists(version)) {
+    console.error(`\n❌ tag v${version} already exists`);
+    console.error(`   → wait for next hour, or use --hour N, or cut --stable`);
+    process.exit(1);
+  }
+
+  const pkgPath = join(process.cwd(), "package.json");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  const old = pkg.version;
+  pkg.version = version;
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  console.log(`✓ package.json: ${old} → ${version}`);
+
+  console.log(`
+Next:
+  git add package.json && git commit -m "bump: v${version}" && git push origin main
+  → auto-tag.yml creates v${version}
+  → release.yml publishes GitHub release
+  → publish.yml → npm (${args.stable ? "latest" : "alpha"} dist-tag)`);
+}
+
+if (import.meta.main) main();

--- a/scripts/ship-alpha.sh
+++ b/scripts/ship-alpha.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ship-alpha.sh — one-command alpha release
+#
+# Flow:
+#   1. Verify clean working tree + on main
+#   2. Ensure package.json version matches an unreleased alpha (caller bumps first)
+#   3. Tag v<version>
+#   4. Push main + tags
+#   5. Fast-forward `alpha` branch to the new tag, force-with-lease push
+#
+# Usage:
+#   scripts/ship-alpha.sh                    # use current package.json version
+#   scripts/ship-alpha.sh --dry-run          # show what would happen
+#
+# Does NOT bump the version. Caller is responsible for:
+#   - committing the bump
+#   - committing any feature/fix commits
+#
+# This script only handles the tag + push mechanics.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=1; fi
+
+cyan()   { printf '\033[36m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+red()    { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+dim()    { printf '\033[90m%s\033[0m\n' "$*"; }
+
+# 1. Preflight
+VERSION=$(grep '"version"' package.json | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+if [[ ! "$VERSION" =~ -alpha\. ]]; then
+  red "error: package.json version '$VERSION' is not an alpha. Bump first."
+  exit 1
+fi
+TAG="v$VERSION"
+
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" ]]; then
+  red "error: must be on main (currently on $BRANCH)"
+  exit 1
+fi
+
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  red "error: working tree not clean. Commit or stash first."
+  exit 1
+fi
+
+if git rev-parse "$TAG" >/dev/null 2>&1; then
+  red "error: tag $TAG already exists"
+  exit 1
+fi
+
+
+cyan "🚢 ship-alpha — $TAG"
+dim "  version: $VERSION"
+dim "  branch:  $BRANCH ($(git rev-parse --short HEAD))"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  dim "  [dry-run] would tag $TAG"
+  dim "  [dry-run] would push main + tags"
+  dim "  [dry-run] would fast-forward alpha branch to $TAG and push"
+  exit 0
+fi
+
+# 2. Tag + push
+git tag "$TAG"
+cyan "  ⏳ pushing main..."
+git push
+cyan "  ⏳ pushing tag $TAG..."
+git push --tags
+
+# 3. Fast-forward alpha branch
+cyan "  ⏳ updating alpha branch..."
+git branch -f alpha "$TAG"
+git push origin alpha --force-with-lease
+
+green "✓ $TAG shipped"
+dim "  main:  $(git rev-parse --short main)"
+dim "  alpha: $(git rev-parse --short alpha)"
+dim "  tag:   $TAG"


### PR DESCRIPTION
Brings over calver.ts from arra-oracle-skills-cli (hour-based bump) and ship-alpha.sh from maw-js (tag + alpha branch FF). Not reinvented — copied.

```
$ bun run scripts/calver.ts --check
Target: v26.4.19-alpha.7  [alpha]
```

Per-hour ceiling: 24 alphas max per day. Each hour can cut at most once.