### PR TITLE
bump: v26.4.19-alpha.7 (first hour-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Phukhao Oracle is landing here: https://phukhao.buildwithoracle.com/presentation
 | | |
 |---|---|
 | **Status** | Always Nightly |
-| **Version** | 26.4.19-alpha.3 |
+| **Version** | 26.4.19-alpha.7 |
 | **Created** | 2025-12-29 |
 | **Updated** | 2026-04-19 |
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.4.19-alpha.3",
+  "version": "26.4.19-alpha.7",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
First release under the hour-based CalVer. `-alpha.7` = cut at 07:xx local. Triggers auto-tag + release.yml.