### PR TITLE
fix(vault): stop creating parasitic ψ/ in every cwd (#551)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import type { VectorStoreAdapter } from './vector/types.ts';
 import path from 'path';
 import fs from 'fs';
 import { loadToolGroupConfig, getDisabledTools, type ToolGroupConfig } from './config/tool-groups.ts';
-import { ORACLE_DATA_DIR, DB_PATH } from './config.ts';
+import { ORACLE_DATA_DIR, DB_PATH, REPO_ROOT } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
 
 // Tool handlers (all extracted to src/tools/)
@@ -89,7 +89,10 @@ class OracleMCPServer {
     if (this.readOnly) {
       console.error('[Oracle] Running in READ-ONLY mode');
     }
-    this.repoRoot = process.env.ORACLE_REPO_ROOT || process.cwd();
+    // Use safe REPO_ROOT from config.ts: never falls back to process.cwd(),
+    // which would create parasitic ψ/ dirs in whatever directory the MCP
+    // server was launched from. See #551.
+    this.repoRoot = REPO_ROOT;
 
     const groupConfig = options.toolGroups ?? loadToolGroupConfig(this.repoRoot);
     this.disabledTools = getDisabledTools(groupConfig);


### PR DESCRIPTION
Closes #551

## Problem

When `ORACLE_REPO_ROOT` env var was unset, `src/index.ts:92` fell back to `process.cwd()`. This caused MCP tool handlers (`arra_handoff`, `arra_learn`, etc.) to create `ψ/` directories in **whatever directory Claude Code was started from**, fragmenting knowledge across up to 10 parasitic locations on a single machine.

## Fix

`src/config.ts` already exports a safe `REPO_ROOT` constant with the correct fallback chain:

1. `ORACLE_REPO_ROOT` env var (explicit override)
2. `ORACLE_DATA_DIR` if it has `ψ/` (canonical data location)
3. `PROJECT_ROOT` if it has `ψ/` (dev mode)
4. `ORACLE_DATA_DIR` (default — never `process.cwd()`)

The MCP server constructor was duplicating the unsafe `process.env.ORACLE_REPO_ROOT || process.cwd()` pattern instead of using the existing safe constant. Replaced it with `REPO_ROOT`.

This cascades naturally to all tool handlers: they read `ctx.repoRoot` from the server, so fixing the root resolution stops the parasitic creation everywhere downstream.

## What changed

- `src/index.ts`: import `REPO_ROOT` from `./config.ts`; use it instead of recomputing the unsafe fallback.

## Test plan

- [ ] Start MCP server from a non-Oracle directory with no `ORACLE_REPO_ROOT` set; confirm no `ψ/` dir is created in that cwd.
- [ ] Run `arra_handoff` from same context; confirm handoff lands in `~/.arra-oracle-v2/ψ/inbox/handoff/`.
- [ ] Existing setups with `ORACLE_REPO_ROOT` set continue to honor it.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle