### PR TITLE
fix(learn): write markdown file to vault alongside DB row (#557)

### DIFF
--- a/src/tools/learn.ts
+++ b/src/tools/learn.ts
@@ -11,6 +11,7 @@ import { oracleDocuments } from '../db/schema.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { getVaultPsiRoot } from '../vault/handler.ts';
 import { getVectorStoreByModel } from '../vector/factory.ts';
+import { REPO_ROOT } from '../config.ts';
 import type { ToolContext, ToolResponse, OracleLearnInput } from './types.ts';
 
 /** Coerce concepts to string[] — handles string, array, or undefined from MCP input */
@@ -135,7 +136,10 @@ export async function handleLearn(ctx: ToolContext, input: OracleLearnInput): Pr
     filePath = path.join(dir, filename);
     sourceFileRel = `${projectDir}/ψ/memory/learnings/${filename}`;
   } else {
-    const dir = path.join(ctx.repoRoot, 'ψ/memory/learnings');
+    // Write to canonical REPO_ROOT, not ctx.repoRoot (the MCP server's cwd):
+    // the dashboard's /api/file resolves source_file against REPO_ROOT, so
+    // writing relative to cwd produces "local file not found" (#557).
+    const dir = path.join(REPO_ROOT, 'ψ/memory/learnings');
     fs.mkdirSync(dir, { recursive: true });
     filePath = path.join(dir, filename);
     sourceFileRel = `ψ/memory/learnings/${filename}`;


### PR DESCRIPTION
Closes #557.

## Root cause

`arra_learn` (MCP tool, `src/tools/learn.ts`) was writing the markdown
file to `ctx.repoRoot/ψ/memory/learnings/`. `ctx.repoRoot` defaults to
`process.cwd()` of the MCP server, so files landed in whatever directory
each Oracle launched the server from — almost never the canonical
`ORACLE_DATA_DIR` (`~/.arra-oracle-v3/`) where the dashboard looks.

The dashboard's `/api/file` route resolves `source_file` against
`REPO_ROOT` (canonical = `ORACLE_DATA_DIR` when it has `ψ/`). Result:
DB row had `source_file: ψ/memory/learnings/...` but the file lived
elsewhere → `⚠️ local file not found` on the Feed page.

## Fix

In the no-vault branch, write to the canonical `REPO_ROOT` instead of
`ctx.repoRoot`. The vault branch was already correct (writes go through
`getVaultPsiRoot()`).

## Test steps

1. Ensure no vault is configured: `sqlite3 ~/.arra-oracle-v3/oracle.db "DELETE FROM oracle_settings WHERE key='vault_repo';"`
2. From any random cwd, run an `arra_learn` call (e.g. via MCP client).
3. Verify the file exists at `~/.arra-oracle-v3/ψ/memory/learnings/<date>_<slug>.md`.
4. Open the dashboard Feed page → entry should render content, not "local file not found".

Existing `learn.test.ts` (12 tests) still passes.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3-oracle