### PR TITLE
feat(cli): arra-cli session list|show|context (#437)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -8,6 +8,9 @@ import type { LoadedPlugin } from "./plugin/types.ts";
 import { pluginsList } from "./commands/plugins-list.ts";
 import { pluginsRemove } from "./commands/plugins-remove.ts";
 import { pluginsInfo } from "./commands/plugins-info.ts";
+import { sessionList } from "./commands/session-list.ts";
+import { sessionShow } from "./commands/session-show.ts";
+import { sessionContext } from "./commands/session-context.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -17,6 +20,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log("Usage: arra-cli <command> [args...]\n");
   console.log("Commands:");
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
+  console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
@@ -58,6 +62,33 @@ async function main() {
   if (cmd === "--version" || cmd === "version") {
     console.log(`arra-cli v${VERSION}`);
     return;
+  }
+
+  if (cmd === "session") {
+    const sub = args[1]?.toLowerCase();
+    const rest = args.slice(2);
+    if (sub === "list" || sub === "ls") {
+      process.exit(await sessionList(rest));
+    }
+    if (sub === "show") {
+      process.exit(await sessionShow(rest));
+    }
+    if (sub === "context") {
+      process.exit(await sessionContext(rest));
+    }
+    if (!sub || sub === "--help" || sub === "-h") {
+      console.log("arra-cli session <subcommand>\n");
+      console.log("Subcommands:");
+      console.log("  list                list all sessions");
+      console.log("  show <id>           show session summary");
+      console.log("  context <id>        dump full session context (--json for machine output)");
+      console.log("\nEnv:");
+      console.log("  ORACLE_API          API base URL (default http://localhost:47778)");
+      return;
+    }
+    console.error(`\x1b[31m✗\x1b[0m unknown session subcommand: ${args[1]}`);
+    console.error("  try: arra-cli session list|show|context");
+    process.exit(1);
   }
 
   if (cmd === "plugin") {

--- a/cli/src/commands/session-api.ts
+++ b/cli/src/commands/session-api.ts
@@ -1,0 +1,19 @@
+export function sessionApiBase(): string {
+  const raw = process.env.ORACLE_API ?? process.env.NEO_ARRA_API ?? "http://localhost:47778";
+  return raw.replace(/\/$/, "");
+}
+
+export async function sessionFetch(path: string, opts?: RequestInit): Promise<Response> {
+  const url = `${sessionApiBase()}${path}`;
+  try {
+    return await fetch(url, opts);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Cannot reach ARRA Oracle at ${sessionApiBase()}\n` +
+      `  → Is the server running? Try: bun run server  (in arra-oracle-v3 repo)\n` +
+      `  → Override with ORACLE_API=http://localhost:<port>\n` +
+      `  Original: ${msg}`,
+    );
+  }
+}

--- a/cli/src/commands/session-context.ts
+++ b/cli/src/commands/session-context.ts
@@ -1,0 +1,76 @@
+import { sessionFetch } from "./session-api.ts";
+
+function fmtTime(v: unknown): string {
+  if (!v) return "—";
+  const s = String(v);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function preview(s: unknown, n = 100): string {
+  if (s == null) return "";
+  return String(s).replace(/\s+/g, " ").slice(0, n);
+}
+
+function printSection(title: string, items: any[], previewKeys: string[]) {
+  console.log(`\n── ${title} (${items.length}) ──`);
+  if (items.length === 0) {
+    console.log("  (none)");
+    return;
+  }
+  for (const item of items) {
+    const id = item.id ?? item.thread_id ?? item.trace_id ?? "—";
+    const when = fmtTime(item.created_at ?? item.createdAt ?? item.updated_at ?? item.timestamp);
+    const body = previewKeys.map(k => item[k]).find(v => v != null);
+    console.log(`  [${id}] ${when}`);
+    const p = preview(body);
+    if (p) console.log(`    ${p}`);
+  }
+}
+
+export async function sessionContext(args: string[]): Promise<number> {
+  const json = args.includes("--json");
+  const id = args.find(a => !a.startsWith("-"));
+  if (!id) {
+    console.error("usage: arra-cli session context <id> [--json]");
+    return 1;
+  }
+
+  let res: Response;
+  try {
+    res = await sessionFetch(`/api/session/${encodeURIComponent(id)}/context`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m session ${id}: HTTP ${res.status}`);
+    if (res.status === 404) {
+      console.error("  not found (or red's backend PR not yet merged)");
+    }
+    return 1;
+  }
+
+  const data = (await res.json()) as any;
+
+  if (json) {
+    console.log(JSON.stringify(data, null, 2));
+    return 0;
+  }
+
+  const session = data.session ?? data;
+  const threads: any[] = data.threads ?? session.threads ?? [];
+  const learnings: any[] = data.learnings ?? session.learnings ?? [];
+  const traces: any[] = data.traces ?? session.traces ?? [];
+
+  console.log(`session:   ${session.id ?? session.session_id ?? id}`);
+  console.log(`oracle:    ${session.oracle ?? session.agent ?? "—"}`);
+  console.log(`started:   ${fmtTime(session.started_at ?? session.startedAt ?? session.created_at)}`);
+  console.log(`ended:     ${fmtTime(session.ended_at ?? session.endedAt ?? session.last_seen)}`);
+
+  printSection("threads", threads, ["title", "subject", "content", "preview"]);
+  printSection("learnings", learnings, ["content", "pattern", "text", "preview"]);
+  printSection("traces", traces, ["content", "message", "text", "preview"]);
+  return 0;
+}

--- a/cli/src/commands/session-list.ts
+++ b/cli/src/commands/session-list.ts
@@ -1,0 +1,74 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+
+function fmtTime(v: unknown): string {
+  if (!v) return "—";
+  const s = String(v);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+export async function sessionList(_args: string[]): Promise<number> {
+  let res: Response;
+  try {
+    res = await sessionFetch("/api/sessions");
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m GET /api/sessions failed: HTTP ${res.status}`);
+    if (res.status === 404) {
+      console.error("  endpoint not found — requires red's backend PR merged first");
+    }
+    return 1;
+  }
+
+  const data = (await res.json()) as any;
+  const sessions: any[] = data.sessions ?? data.results ?? (Array.isArray(data) ? data : []);
+
+  if (sessions.length === 0) {
+    console.log(`no sessions (${sessionApiBase()})`);
+    return 0;
+  }
+
+  type Row = {
+    id: string;
+    oracle: string;
+    lastSeen: string;
+    threads: string;
+    learnings: string;
+    traces: string;
+  };
+
+  const rows: Row[] = sessions.map(s => ({
+    id: String(s.id ?? s.session_id ?? s.sessionId ?? "—"),
+    oracle: String(s.oracle ?? s.agent ?? "—"),
+    lastSeen: fmtTime(s.last_seen ?? s.lastSeen ?? s.updated_at ?? s.ended_at),
+    threads: String(s.threads_count ?? s.threads ?? s.counts?.threads ?? 0),
+    learnings: String(s.learnings_count ?? s.learnings ?? s.counts?.learnings ?? 0),
+    traces: String(s.traces_count ?? s.traces ?? s.counts?.traces ?? 0),
+  }));
+
+  const cols = [
+    { key: "id", head: "SESSION_ID" },
+    { key: "oracle", head: "ORACLE" },
+    { key: "lastSeen", head: "LAST_SEEN" },
+    { key: "threads", head: "#THREADS" },
+    { key: "learnings", head: "#LEARNINGS" },
+    { key: "traces", head: "#TRACES" },
+  ] as const;
+
+  const widths = cols.map(c =>
+    Math.max(c.head.length, ...rows.map(r => (r[c.key as keyof Row] ?? "").length)),
+  );
+
+  const line = (vals: string[]) =>
+    vals.map((v, i) => v.padEnd(widths[i])).join("  ").trimEnd();
+
+  console.log(line(cols.map(c => c.head)));
+  for (const r of rows) {
+    console.log(line(cols.map(c => r[c.key as keyof Row])));
+  }
+  return 0;
+}

--- a/cli/src/commands/session-show.ts
+++ b/cli/src/commands/session-show.ts
@@ -1,0 +1,61 @@
+import { sessionFetch } from "./session-api.ts";
+
+function fmtTime(v: unknown): string {
+  if (!v) return "—";
+  const s = String(v);
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s;
+  return d.toISOString().replace("T", " ").slice(0, 19);
+}
+
+function pickCount(s: any, ...keys: string[]): number {
+  for (const k of keys) {
+    const v = s?.[k] ?? s?.counts?.[k.replace(/_count$/, "")];
+    if (typeof v === "number") return v;
+  }
+  return 0;
+}
+
+export async function sessionShow(args: string[]): Promise<number> {
+  const id = args.find(a => !a.startsWith("-"));
+  if (!id) {
+    console.error("usage: arra-cli session show <id>");
+    return 1;
+  }
+
+  let res: Response;
+  try {
+    res = await sessionFetch(`/api/session/${encodeURIComponent(id)}/context`);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m session ${id}: HTTP ${res.status}`);
+    if (res.status === 404) {
+      console.error("  not found (or red's backend PR not yet merged)");
+    }
+    return 1;
+  }
+
+  const data = (await res.json()) as any;
+  const session = data.session ?? data;
+
+  const threads = data.threads ?? session.threads ?? [];
+  const learnings = data.learnings ?? session.learnings ?? [];
+  const traces = data.traces ?? session.traces ?? [];
+
+  const threadsN = Array.isArray(threads) ? threads.length : pickCount(session, "threads_count", "threads");
+  const learningsN = Array.isArray(learnings) ? learnings.length : pickCount(session, "learnings_count", "learnings");
+  const tracesN = Array.isArray(traces) ? traces.length : pickCount(session, "traces_count", "traces");
+
+  console.log(`session:   ${session.id ?? session.session_id ?? id}`);
+  console.log(`oracle:    ${session.oracle ?? session.agent ?? "—"}`);
+  console.log(`started:   ${fmtTime(session.started_at ?? session.startedAt ?? session.created_at)}`);
+  console.log(`ended:     ${fmtTime(session.ended_at ?? session.endedAt ?? session.last_seen)}`);
+  console.log("");
+  console.log(`threads:   ${threadsN}`);
+  console.log(`learnings: ${learningsN}`);
+  console.log(`traces:    ${tracesN}`);
+  return 0;
+}


### PR DESCRIPTION
Part B of #437. Depends on red's backend endpoints PR.

## Summary
- New `arra-cli session list|show|context` subcommands
- `list` → table of SESSION_ID · ORACLE · LAST_SEEN · #THREADS · #LEARNINGS · #TRACES
- `show <id>` → pretty-print session id, oracle, started/ended, counts
- `context <id>` → dumps recent threads/learnings/traces with previews; `--json` for machine output
- API base defaults to `http://localhost:47778`, overridable via `ORACLE_API`
- Gracefully reports 404 with "requires red's backend PR merged first" when endpoints absent

## Test plan
- [x] `arra-cli session --help` prints subcommand help
- [x] `arra-cli session show` / `context` with no id prints usage
- [x] `arra-cli session list` gracefully reports 404 until red's backend PR lands
- [ ] Full run-through once red's `GET /api/sessions` and `GET /api/session/:id/context` are merged

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle