### PR TITLE
fix(types): resolve tsc --noEmit errors in handlers + search

### DIFF
--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -19,6 +19,7 @@ export interface SearchResponse {
   total: number;
   offset: number;
   limit: number;
+  query?: string;
 }
 
 export interface StatsResponse {

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -9,6 +9,7 @@
 import { logSearch } from '../server/logging.ts';
 import { detectProject } from '../server/project-detect.ts';
 import { ensureVectorStoreConnected } from '../vector/factory.ts';
+import type { SearchResult } from '../server/types.ts';
 import type { ToolContext, ToolResponse, OracleSearchInput } from './types.ts';
 
 export const searchToolDef = {
@@ -455,7 +456,7 @@ export async function handleSearch(ctx: ToolContext, input: OracleSearchInput): 
   console.error(`[MCP:SEARCH] "${query}" (${type}, ${mode}, model=${model || 'default'}) → ${results.length} results in ${searchTime}ms`);
 
   try {
-    logSearch(query, type, mode, results.length, searchTime, results);
+    logSearch(query, type, mode, results.length, searchTime, results as unknown as SearchResult[]);
   } catch (e) {
     console.error('[MCP:SEARCH] Failed to log search to database:', e);
   }


### PR DESCRIPTION
## Summary
Fixes two pre-existing tsc errors that blocked \`bun run build\` cleanly for weeks:

- \`src/server/handlers.ts:49\` — SearchResponse missing \`query\` field
- \`src/tools/search.ts:458\` — logSearch expected SearchResult[] but got enriched Record<string, unknown>[]

## Fixes
- Added \`query?: string\` to SearchResponse interface (matches actual handler behavior)
- Added inline cast at logSearch call site + imported SearchResult type

## Test plan
- [x] \`bun run build\` → clean
- [x] \`bun run test:unit\` → 145 pass

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle