### PR TITLE
feat(elysia): compose 15 Elysia sub-apps, swap Hono → Elysia, add /swagger + root /

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "oracle-v2-mcp",
       "dependencies": {
         "@elysiajs/cors": "^1.4.1",
+        "@elysiajs/swagger": "^1.3.1",
         "@lancedb/lancedb": "^0.27.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@qdrant/js-client-rest": "^1.17.0",
@@ -31,6 +32,8 @@
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.1", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-lQfad+F3r4mNwsxRKbXyJB8Jg43oAOXjRwn7sKUL6bcOW3KjUqUimTS+woNpO97efpzjtDE0tEjGk9DTw8lqTQ=="],
+
+    "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -112,6 +115,12 @@
 
     "@qdrant/openapi-typescript-fetch": ["@qdrant/openapi-typescript-fetch@1.2.6", "", {}, "sha512-oQG/FejNpItrxRHoyctYvT3rwGZOnK4jr3JdppO/c78ktDvkWiPXPHNsrDf33K9sZdRb6PR7gi4noIapu5q4HA=="],
 
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
+
+    "@scalar/themes": ["@scalar/themes@0.9.86", "", { "dependencies": { "@scalar/types": "0.1.7" } }, "sha512-QUHo9g5oSWi+0Lm1vJY9TaMZRau8LHg+vte7q5BVTBnu6NuQfigCaN+ouQ73FqIVd96TwMO6Db+dilK1B+9row=="],
+
+    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
+
     "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.19", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-QamiFeIK3txNjgUTNppE6MiG3p7TdninpZu0E0PbqVh1a9FNLT2FRhisaa4NcaX52XVhA5l7Pk58Ft7Sqi/2sA=="],
@@ -127,6 +136,8 @@
     "@types/command-line-usage": ["@types/command-line-usage@5.0.4", "", {}, "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="],
 
     "@types/node": ["@types/node@20.19.27", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug=="],
+
+    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -282,6 +293,8 @@
 
     "hono": ["hono@4.12.14", "", {}, "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w=="],
 
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.1", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw=="],
@@ -330,6 +343,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
+
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
@@ -351,6 +366,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
@@ -448,6 +465,8 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -472,11 +491,15 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
+
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
 
     "command-line-usage/array-back": ["array-back@6.2.2", "", {}, "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw=="],
 
@@ -531,6 +554,8 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@elysiajs/cors": "^1.4.1",
+    "@elysiajs/swagger": "^1.3.1",
     "@lancedb/lancedb": "^0.27.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@qdrant/js-client-rest": "^1.17.0",

--- a/src/routes-elysia/sessions/index.ts
+++ b/src/routes-elysia/sessions/index.ts
@@ -1,0 +1,4 @@
+import { Elysia } from 'elysia';
+import { summaryRoute } from './summary.ts';
+
+export const sessionsRoutes = new Elysia().use(summaryRoute);

--- a/src/routes-elysia/sessions/model.ts
+++ b/src/routes-elysia/sessions/model.ts
@@ -1,0 +1,12 @@
+import { t } from 'elysia';
+
+export const MAX_SUMMARY_CHARS = 4000;
+
+export const SummaryParams = t.Object({
+  id: t.String({ minLength: 1 }),
+});
+
+export const SummaryBody = t.Object({
+  summary: t.String(),
+  oracle: t.Optional(t.String()),
+});

--- a/src/routes-elysia/sessions/summary.ts
+++ b/src/routes-elysia/sessions/summary.ts
@@ -1,0 +1,21 @@
+import { Elysia } from 'elysia';
+import { handleSessionSummary } from '../../server/handlers.ts';
+import { SummaryParams, SummaryBody, MAX_SUMMARY_CHARS } from './model.ts';
+
+export const summaryRoute = new Elysia().post(
+  '/api/session/:id/summary',
+  ({ params, body, set }) => {
+    const summary = body.summary;
+    if (summary.trim().length === 0) {
+      set.status = 400;
+      return { error: 'Missing required field: summary' };
+    }
+    if (summary.length > MAX_SUMMARY_CHARS) {
+      set.status = 400;
+      return { error: `summary exceeds max length (${MAX_SUMMARY_CHARS} chars)` };
+    }
+    set.status = 201;
+    return handleSessionSummary(params.id, summary, body.oracle);
+  },
+  { params: SummaryParams, body: SummaryBody },
+);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,13 @@
 /**
- * Arra Oracle HTTP Server - Hono.js Version
+ * Arra Oracle HTTP Server — Elysia (bun-native).
  *
- * Modern routing with Hono.js on Bun runtime.
- * Routes split into modules under src/routes/.
+ * Composes 15 route modules from src/routes-elysia/. Every module is its own
+ * Elysia sub-app, nested one file per endpoint.
  */
 
-import { Hono } from 'hono';
-import { cors } from 'hono/cors';
+import { Elysia } from 'elysia';
+import { cors } from '@elysiajs/cors';
+import { swagger } from '@elysiajs/swagger';
 import { eq } from 'drizzle-orm';
 
 import {
@@ -18,58 +19,52 @@ import {
 } from './process-manager/index.ts';
 
 import { PORT, ORACLE_DATA_DIR } from './config.ts';
+import { MCP_SERVER_NAME } from './const.ts';
 import { db, closeDb, indexingStatus } from './db/index.ts';
 
-// Route modules
-import { registerAuthRoutes } from './routes/auth.ts';
-import { registerSettingsRoutes } from './routes/settings.ts';
-import { registerHealthRoutes } from './routes/health.ts';
-import { registerSearchRoutes } from './routes/search.ts';
-import { registerFeedRoutes } from './routes/feed.ts';
-import { registerDashboardRoutes } from './routes/dashboard.ts';
-import { registerForumRoutes } from './routes/forum.ts';
-import { registerScheduleRoutes } from './routes/schedule.ts';
-import { registerTraceRoutes } from './routes/traces.ts';
-import { registerKnowledgeRoutes } from './routes/knowledge.ts';
-import { registerSupersedeRoutes } from './routes/supersede.ts';
-import { registerFileRoutes } from './routes/files.ts';
-import { registerOracleNetRoutes } from './routes/oraclenet.ts';
-import { registerPluginRoutes } from './routes/plugins.ts';
-import { registerSessionSummaryRoutes } from './routes/session-summary.ts';
+// Elysia sub-apps — one per cluster
+import { authRoutes } from './routes-elysia/auth/index.ts';
+import { settingsRoutes } from './routes-elysia/settings/index.ts';
+import { feedRoutes } from './routes-elysia/feed/index.ts';
+import { healthRoutes } from './routes-elysia/health/index.ts';
+import { dashboardRoutes } from './routes-elysia/dashboard/index.ts';
+import { searchRoutes } from './routes-elysia/search/index.ts';
+import { knowledgeRoutes } from './routes-elysia/knowledge/index.ts';
+import { supersedeRoutes } from './routes-elysia/supersede/index.ts';
+import { forumApi } from './routes-elysia/forum/index.ts';
+import { tracesApi } from './routes-elysia/traces/index.ts';
+import { scheduleApi } from './routes-elysia/schedule/index.ts';
+import { filesRouter } from './routes-elysia/files/index.ts';
+import { pluginsRouter } from './routes-elysia/plugins/index.ts';
+import { oraclenetRoutes } from './routes-elysia/oraclenet/index.ts';
+import { sessionsRoutes } from './routes-elysia/sessions/index.ts';
 
-// Reset stale indexing status on startup using Drizzle
+import pkg from '../package.json' with { type: 'json' };
+
 try {
-  db.update(indexingStatus)
-    .set({ isIndexing: 0 })
-    .where(eq(indexingStatus.id, 1))
-    .run();
+  db.update(indexingStatus).set({ isIndexing: 0 }).where(eq(indexingStatus.id, 1)).run();
   console.log('🔮 Reset indexing status on startup');
 } catch (e) {
-  // Table might not exist yet - that's fine
+  // table might not exist yet — fine on first boot
 }
 
-// Configure process lifecycle management
 configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
+writePidFile({
+  pid: process.pid,
+  port: Number(PORT),
+  startedAt: new Date().toISOString(),
+  name: 'oracle-http',
+});
 
-// Write PID file for process tracking
-writePidFile({ pid: process.pid, port: Number(PORT), startedAt: new Date().toISOString(), name: 'oracle-http' });
-
-// Register graceful shutdown handlers
 registerSignalHandlers(async () => {
   console.log('\n🔮 Shutting down gracefully...');
   await performGracefulShutdown({
-    resources: [
-      { close: () => { closeDb(); return Promise.resolve(); } }
-    ]
+    resources: [{ close: () => { closeDb(); return Promise.resolve(); } }],
   });
   removePidFile();
   console.log('👋 Arra Oracle HTTP Server stopped.');
 });
 
-// Create Hono app
-const app = new Hono();
-
-// CORS middleware — allow studio + neo + localhost, plus ORACLE_CORS_ORIGIN override
 const DEFAULT_ALLOWED_ORIGINS = [
   'https://studio.buildwithoracle.com',
   'https://neo.buildwithoracle.com',
@@ -85,7 +80,7 @@ const ALLOWED_ORIGINS = [
   ...(legacyOrigin ? [legacyOrigin] : []),
 ];
 
-function originAllowed(origin: string | undefined): string | null {
+function originAllowed(origin: string | undefined | null): string | null {
   if (!origin) return null;
   if (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')) {
     return origin;
@@ -94,95 +89,97 @@ function originAllowed(origin: string | undefined): string | null {
   return null;
 }
 
-// Private Network Access preflight (Chrome 117+): must run BEFORE hono/cors,
-// because hono/cors responds to OPTIONS directly and bypasses later middleware.
-// Lets studio.buildwithoracle.com fetch a user's local MCP at :47778.
-app.use('*', async (c, next) => {
+// Private Network Access preflight (Chrome 117+). Must intercept OPTIONS
+// before @elysiajs/cors, because the cors plugin answers preflights itself
+// without emitting the `Access-Control-Allow-Private-Network` header that
+// Chrome requires for https→localhost fetches.
+const pnaMiddleware = new Elysia().onRequest(({ request }) => {
   if (
-    c.req.method === 'OPTIONS' &&
-    c.req.header('access-control-request-private-network') === 'true'
+    request.method === 'OPTIONS' &&
+    request.headers.get('access-control-request-private-network') === 'true'
   ) {
-    const origin = originAllowed(c.req.header('origin'));
-    if (!origin) return next();
+    const origin = originAllowed(request.headers.get('origin'));
+    if (!origin) return;
     return new Response(null, {
       status: 204,
       headers: {
         'Access-Control-Allow-Origin': origin,
         'Access-Control-Allow-Credentials': 'true',
-        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,OPTIONS',
+        'Access-Control-Allow-Methods': 'GET,POST,PUT,DELETE,PATCH,OPTIONS',
         'Access-Control-Allow-Headers':
-          c.req.header('access-control-request-headers') ?? 'content-type',
+          request.headers.get('access-control-request-headers') ?? 'content-type',
         'Access-Control-Allow-Private-Network': 'true',
         'Access-Control-Max-Age': '86400',
         Vary: 'Origin',
       },
     });
   }
-  return next();
 });
 
-app.use('*', cors({
-  origin: (origin) => originAllowed(origin) ?? null,
-  credentials: true,
-  allowMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
-}));
+const app = new Elysia()
+  .use(pnaMiddleware)
+  .use(
+    cors({
+      origin: (request) => {
+        const origin = request.headers.get('origin');
+        return originAllowed(origin) !== null;
+      },
+      credentials: true,
+      methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    }),
+  )
+  .onAfterHandle(({ set }) => {
+    set.headers['X-Content-Type-Options'] = 'nosniff';
+    set.headers['X-Frame-Options'] = 'DENY';
+    set.headers['X-XSS-Protection'] = '1; mode=block';
+    set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
+  })
+  .use(
+    swagger({
+      path: '/swagger',
+      documentation: {
+        info: {
+          title: 'Arra Oracle API',
+          version: pkg.version,
+          description: 'HTTP API for the Arra Oracle MCP memory layer.',
+        },
+      },
+    }),
+  )
+  .get('/', () => ({
+    server: MCP_SERVER_NAME,
+    version: pkg.version,
+    status: 'ok',
+    docs: '/swagger',
+    api: '/api',
+  }));
 
-// Security headers middleware
-app.use('*', async (c, next) => {
-  await next();
-  c.header('X-Content-Type-Options', 'nosniff');
-  c.header('X-Frame-Options', 'DENY');
-  c.header('X-XSS-Protection', '1; mode=block');
-  c.header('Referrer-Policy', 'strict-origin-when-cross-origin');
-});
+const modules = [
+  authRoutes,
+  settingsRoutes,
+  feedRoutes,
+  healthRoutes,
+  dashboardRoutes,
+  searchRoutes,
+  knowledgeRoutes,
+  supersedeRoutes,
+  forumApi,
+  tracesApi,
+  scheduleApi,
+  filesRouter,
+  pluginsRouter,
+  oraclenetRoutes,
+  sessionsRoutes,
+];
 
-// Register all route modules (order matters: auth middleware first)
-registerAuthRoutes(app);
-registerSettingsRoutes(app);
-registerHealthRoutes(app);
-registerSearchRoutes(app);
-registerFeedRoutes(app);
-registerDashboardRoutes(app);
-registerForumRoutes(app);
-registerScheduleRoutes(app);
-registerTraceRoutes(app);
-registerKnowledgeRoutes(app);
-registerSupersedeRoutes(app);
-registerFileRoutes(app);
-registerOracleNetRoutes(app);
-registerPluginRoutes(app);
-registerSessionSummaryRoutes(app);
+for (const mod of modules) app.use(mod as any);
 
-// Startup banner
 console.log(`
-🔮 Arra Oracle HTTP Server running! (Hono.js)
+🔮 Arra Oracle HTTP Server running! (Elysia)
 
-   URL: http://localhost:${PORT}
-
-   Endpoints:
-   - GET  /api/health          Health check
-   - GET  /api/search?q=...    Search Oracle knowledge
-   - GET  /api/list            Browse all documents
-   - GET  /api/reflect         Random wisdom
-   - GET  /api/stats           Database statistics
-   - GET  /api/graph           Knowledge graph data
-   - GET  /api/map             Knowledge map 2D (hash-based layout)
-   - GET  /api/map3d           Knowledge map 3D (real PCA from LanceDB embeddings)
-   - GET  /api/context         Project context (ghq format)
-   - POST /api/learn           Add new pattern/learning
-
-   Forum:
-   - GET  /api/threads         List threads
-   - GET  /api/thread/:id      Get thread
-   - POST /api/thread          Send message
-
-   Supersede Log:
-   - GET  /api/supersede       List supersessions
-   - GET  /api/supersede/chain/:path  Document lineage
-   - POST /api/supersede       Log supersession
-
-   Sessions:
-   - POST /api/session/:id/summary  Write session summary as learning
+   URL:     http://localhost:${PORT}
+   Swagger: http://localhost:${PORT}/swagger
+   Version: ${pkg.version}
 `);
 
 export default {


### PR DESCRIPTION
## Summary
Phase 2 of Elysia migration — composes the 15 sub-apps from #882-#886 into a live server.

- Replaces Hono with Elysia in src/server.ts
- Mounts all 14 route clusters + new src/routes-elysia/sessions (session-summary port)
- Adds @elysiajs/swagger at /swagger (auto OpenAPI 3 from TypeBox)
- Adds root GET / returning { server, version, status, docs, api }
- Preserves CORS + PNA + security headers + graceful shutdown
- Collapses the 15 .use() calls into an array iteration (user asked for this)

## Test results
99 / 103 HTTP contract tests pass. The 4 failing trace-link tests are pre-existing (same failures on main branch Hono) and unrelated to Elysia — tracked separately as a test-isolation issue.

## Next (follow-up PRs, assigned to a new team)
- Delete src/routes/*.ts (Hono) + remove hono dep
- Rename src/routes-elysia/ → src/routes/
- Fix trace test isolation
- CLI default JSON + --yml
- Add tests/cli/ integration tests driven via CLI

🤖 ตอบโดย arra-oracle-v3 จาก [Nat Weerawan] → arra-oracle-v3-oracle