### PR TITLE
feat(cli): switch CLI default to JSON, add --yml flag

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -81,7 +81,8 @@ async function main() {
       console.log("Subcommands:");
       console.log("  list                list all sessions");
       console.log("  show <id>           show session summary");
-      console.log("  context <id>        dump full session context (--json for machine output)");
+      console.log("  context <id>        dump full session context");
+      console.log("\nOutput defaults to JSON; pass --yml for YAML.");
       console.log("\nEnv:");
       console.log("  ORACLE_API          API base URL (default http://localhost:47778)");
       return;
@@ -93,19 +94,32 @@ async function main() {
 
   if (cmd === "plugin") {
     const sub = args[1]?.toLowerCase();
+    const rest = args.slice(2);
     if (sub === "install") {
       const { runInstallCli } = await import("./commands/plugins-install.ts");
-      const code = await runInstallCli(args.slice(2));
-      process.exit(code);
+      process.exit(await runInstallCli(rest));
+    }
+    if (sub === "list" || sub === "ls") {
+      process.exit(await pluginsList(rest));
+    }
+    if (sub === "remove" || sub === "rm") {
+      process.exit(await pluginsRemove(rest));
+    }
+    if (sub === "info") {
+      process.exit(await pluginsInfo(rest));
     }
     if (!sub || sub === "--help" || sub === "-h") {
       console.log("arra-cli plugin <subcommand>\n");
       console.log("Subcommands:");
+      console.log("  list                    list installed plugins");
+      console.log("  info <name>             show plugin details");
       console.log("  install <url-or-path>   install a plugin (see --help)");
+      console.log("  remove <name>           remove an installed plugin");
+      console.log("\nOutput defaults to JSON; pass --yml for YAML.");
       return;
     }
     console.error(`\x1b[31m✗\x1b[0m unknown plugin subcommand: ${args[1]}`);
-    console.error("  try: arra-cli plugin install <url-or-path>");
+    console.error("  try: arra-cli plugin list|info|install|remove");
     process.exit(1);
   }
 
@@ -135,20 +149,6 @@ async function main() {
     }
     printCommandHelp(plugin);
     return;
-  }
-
-  if (cmd === "plugin") {
-    const sub = args[1]?.toLowerCase();
-    const rest = args.slice(2);
-    if (sub === "list" || sub === "ls") {
-      process.exit(await pluginsList(rest));
-    }
-    if (sub === "remove" || sub === "rm") {
-      process.exit(await pluginsRemove(rest));
-    }
-    if (sub === "info") {
-      process.exit(await pluginsInfo(rest));
-    }
   }
 
   await loadAll();

--- a/cli/src/commands/_output.ts
+++ b/cli/src/commands/_output.ts
@@ -1,0 +1,10 @@
+export function emit(data: unknown, args: string[]): void {
+  const yaml = args.includes("--yml") || args.includes("--yaml");
+  if (yaml) {
+    // @ts-expect-error Bun.YAML is available at runtime in Bun ≥1.1
+    const out = Bun.YAML.stringify(data);
+    process.stdout.write(out.endsWith("\n") ? out : out + "\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+}

--- a/cli/src/commands/plugins-info.ts
+++ b/cli/src/commands/plugins-info.ts
@@ -1,29 +1,21 @@
 import { join } from "path";
 import { homedir } from "os";
 import { existsSync, readFileSync, statSync } from "fs";
+import { emit } from "./_output.ts";
 
 const ORACLE_PLUGIN_DIR = join(homedir(), ".oracle", "plugins");
 
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
-
-async function printWasmExports(wasmPath: string): Promise<void> {
+async function wasmExports(wasmPath: string): Promise<
+  | { exports: Array<{ kind: string; name: string }> }
+  | { error: string }
+> {
   try {
     const bytes = await Bun.file(wasmPath).arrayBuffer();
     const mod = await WebAssembly.compile(bytes);
     const exports = WebAssembly.Module.exports(mod);
-    if (exports.length === 0) {
-      console.log("  (no exports)");
-      return;
-    }
-    for (const ex of exports) {
-      console.log(`  ${ex.kind.padEnd(10)} ${ex.name}`);
-    }
+    return { exports: exports.map(e => ({ kind: e.kind, name: e.name })) };
   } catch (err) {
-    console.log(`  (failed to compile: ${err instanceof Error ? err.message : String(err)})`);
+    return { error: err instanceof Error ? err.message : String(err) };
   }
 }
 
@@ -60,23 +52,21 @@ export async function pluginsInfo(args: string[]): Promise<number> {
     return 1;
   }
 
-  console.log(`plugin: ${name}`);
-
-  if (manifest) {
-    console.log("\nmanifest:");
-    console.log(JSON.stringify(manifest, null, 2));
-  }
+  const result: Record<string, unknown> = { name, manifest };
 
   if (wasmPath) {
     const stat = statSync(wasmPath);
-    console.log(`\nartifact: ${wasmPath}`);
-    console.log(`  size:     ${formatSize(stat.size)} (${stat.size} bytes)`);
-    console.log(`  modified: ${stat.mtime.toISOString()}`);
-    console.log("\nexports:");
-    await printWasmExports(wasmPath);
+    const xp = await wasmExports(wasmPath);
+    result.artifact = {
+      path: wasmPath,
+      size: stat.size,
+      modified: stat.mtime.toISOString(),
+      ...xp,
+    };
   } else {
-    console.log("\n(no .wasm artifact found)");
+    result.artifact = null;
   }
 
+  emit(result, args);
   return 0;
 }

--- a/cli/src/commands/plugins-install.ts
+++ b/cli/src/commands/plugins-install.ts
@@ -8,6 +8,7 @@ import {
 } from "fs";
 import { homedir } from "os";
 import { basename, dirname, isAbsolute, join, resolve } from "path";
+import { emit } from "./_output.ts";
 
 export interface InstallManifest {
   name: string;
@@ -27,6 +28,19 @@ export interface InstallOptions {
   manifest?: string;
 }
 
+export interface InstallResult {
+  installed: boolean;
+  dryRun: boolean;
+  name: string;
+  version: string;
+  dest: string;
+  wasmDest: string;
+  manifestDest: string;
+  source: "artifact" | "git" | "path";
+  synthesizedManifest?: boolean;
+}
+
+const log = (...a: unknown[]) => console.error(...a);
 const C = {
   cyan: (s: string) => `\x1b[36m${s}\x1b[0m`,
   green: (s: string) => `\x1b[32m${s}\x1b[0m`,
@@ -96,7 +110,7 @@ function toCloneUrl(s: string): string {
 }
 
 async function ghqClone(url: string): Promise<string> {
-  console.log(`${C.cyan("⚡")} cloning ${url} via ghq...`);
+  log(`${C.cyan("⚡")} cloning ${url} via ghq...`);
   const clone = Bun.spawn(["ghq", "get", "-u", url], {
     stdout: "inherit",
     stderr: "inherit",
@@ -126,7 +140,7 @@ async function ghqClone(url: string): Promise<string> {
 }
 
 async function runBuild(cmd: string, cwd: string): Promise<void> {
-  console.log(`${C.cyan("⚡")} building: ${C.dim(cmd)}`);
+  log(`${C.cyan("⚡")} building: ${C.dim(cmd)}`);
   const parts = cmd.match(/(?:[^\s"']+|"[^"]*"|'[^']*')+/g);
   if (!parts || parts.length === 0) {
     throw new Error(`cannot parse build command: ${cmd}`);
@@ -162,10 +176,11 @@ function synthesizeManifest(artifactUrl: string): InstallManifest {
   return { name, version: "0.0.0", wasm: basename(artifactUrl) };
 }
 
-async function installFromArtifact(opts: InstallOptions): Promise<void> {
+async function installFromArtifact(opts: InstallOptions): Promise<InstallResult> {
   if (!opts.artifact) throw new Error("--artifact requires a URL");
 
   let manifest: InstallManifest;
+  let synthesized = false;
   if (opts.manifest) {
     const res = await fetch(opts.manifest);
     if (!res.ok) {
@@ -174,7 +189,8 @@ async function installFromArtifact(opts: InstallOptions): Promise<void> {
     manifest = parseInstallManifest(await res.text());
   } else {
     manifest = synthesizeManifest(opts.artifact);
-    console.log(
+    synthesized = true;
+    log(
       `${C.yellow("!")} synthesized manifest ${manifest.name}@${manifest.version} from filename`,
     );
   }
@@ -190,9 +206,17 @@ async function installFromArtifact(opts: InstallOptions): Promise<void> {
   const manifestDest = join(dest, "plugin.json");
 
   if (opts.dryRun) {
-    console.log(`${C.dim("[dry-run]")} would fetch ${opts.artifact} → ${wasmDest}`);
-    console.log(`${C.dim("[dry-run]")} would write plugin.json → ${manifestDest}`);
-    return;
+    return {
+      installed: false,
+      dryRun: true,
+      name: manifest.name,
+      version: manifest.version,
+      dest,
+      wasmDest,
+      manifestDest,
+      source: "artifact",
+      synthesizedManifest: synthesized,
+    };
   }
 
   if (existsSync(dest) && opts.force) {
@@ -201,20 +225,31 @@ async function installFromArtifact(opts: InstallOptions): Promise<void> {
   mkdirSync(dest, { recursive: true });
   await downloadTo(opts.artifact, wasmDest);
   writeFileSync(manifestDest, JSON.stringify(manifest, null, 2));
-  console.log(
-    `${C.green("✓")} installed ${manifest.name}@${manifest.version} → ${dest}`,
-  );
+  return {
+    installed: true,
+    dryRun: false,
+    name: manifest.name,
+    version: manifest.version,
+    dest,
+    wasmDest,
+    manifestDest,
+    source: "artifact",
+    synthesizedManifest: synthesized,
+  };
 }
 
-async function installFromSource(source: string, opts: InstallOptions): Promise<void> {
+async function installFromSource(source: string, opts: InstallOptions): Promise<InstallResult> {
   let src: string;
+  let kind: "git" | "path";
   if (isUrlLike(source)) {
     src = await ghqClone(toCloneUrl(source));
+    kind = "git";
   } else {
     src = isAbsolute(source) ? source : resolve(source);
     if (!existsSync(src)) {
       throw new Error(`path not found: ${src}`);
     }
+    kind = "path";
   }
 
   const manifestPath = join(src, "plugin.json");
@@ -248,9 +283,16 @@ async function installFromSource(source: string, opts: InstallOptions): Promise<
   const manifestDest = join(dest, "plugin.json");
 
   if (opts.dryRun) {
-    console.log(`${C.dim("[dry-run]")} would copy ${wasmPath} → ${wasmDest}`);
-    console.log(`${C.dim("[dry-run]")} would copy ${manifestPath} → ${manifestDest}`);
-    return;
+    return {
+      installed: false,
+      dryRun: true,
+      name: manifest.name,
+      version: manifest.version,
+      dest,
+      wasmDest,
+      manifestDest,
+      source: kind,
+    };
   }
 
   if (existsSync(dest) && opts.force) {
@@ -259,25 +301,31 @@ async function installFromSource(source: string, opts: InstallOptions): Promise<
   mkdirSync(dest, { recursive: true });
   copyFileSync(wasmPath, wasmDest);
   copyFileSync(manifestPath, manifestDest);
-  console.log(
-    `${C.green("✓")} installed ${manifest.name}@${manifest.version} → ${dest}`,
-  );
+  return {
+    installed: true,
+    dryRun: false,
+    name: manifest.name,
+    version: manifest.version,
+    dest,
+    wasmDest,
+    manifestDest,
+    source: kind,
+  };
 }
 
 export async function doInstall(
   source: string | undefined,
   opts: InstallOptions,
-): Promise<void> {
+): Promise<InstallResult> {
   if (opts.artifact) {
-    await installFromArtifact(opts);
-    return;
+    return await installFromArtifact(opts);
   }
   if (!source) {
     throw new Error(
       "missing <url-or-path>; see 'arra-cli plugin install --help'",
     );
   }
-  await installFromSource(source, opts);
+  return await installFromSource(source, opts);
 }
 
 export function printInstallHelp(): void {
@@ -295,6 +343,7 @@ export function printInstallHelp(): void {
   console.log("  --artifact <url>     download prebuilt .wasm directly (skip clone+build)");
   console.log("  --manifest <url>     plugin.json URL to pair with --artifact");
   console.log("                       (if omitted, manifest is synthesized from filename)");
+  console.log("  --yml, --yaml        emit YAML instead of JSON");
   console.log("  -h, --help           show this help");
 }
 
@@ -324,6 +373,8 @@ export async function runInstallCli(args: string[]): Promise<number> {
     } else if (a === "-h" || a === "--help") {
       printInstallHelp();
       return 0;
+    } else if (a === "--yml" || a === "--yaml") {
+      // consumed by emit()
     } else if (a.startsWith("--") || a.startsWith("-")) {
       console.error(`${C.red("✗")} unknown flag: ${a}`);
       return 1;
@@ -333,7 +384,8 @@ export async function runInstallCli(args: string[]): Promise<number> {
   }
 
   try {
-    await doInstall(positional[0], opts);
+    const result = await doInstall(positional[0], opts);
+    emit(result, args);
     return 0;
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);

--- a/cli/src/commands/plugins-list.ts
+++ b/cli/src/commands/plugins-list.ts
@@ -1,6 +1,7 @@
 import { join } from "path";
 import { homedir } from "os";
 import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { emit } from "./_output.ts";
 
 const ORACLE_PLUGIN_DIR = join(homedir(), ".oracle", "plugins");
 
@@ -8,12 +9,6 @@ interface Row {
   name: string;
   version: string;
   size: number;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 function readDirPlugin(dir: string, name: string): Row | null {
@@ -34,40 +29,26 @@ function readDirPlugin(dir: string, name: string): Row | null {
   }
 }
 
-export async function pluginsList(_args: string[]): Promise<number> {
-  if (!existsSync(ORACLE_PLUGIN_DIR)) {
-    console.log(`no plugins installed (${ORACLE_PLUGIN_DIR} does not exist)`);
-    return 0;
-  }
-
+export async function pluginsList(args: string[]): Promise<number> {
   const rows: Row[] = [];
-  const entries = readdirSync(ORACLE_PLUGIN_DIR, { withFileTypes: true });
 
-  for (const entry of entries) {
-    const entryPath = join(ORACLE_PLUGIN_DIR, entry.name);
-    if (entry.isDirectory()) {
-      const row = readDirPlugin(entryPath, entry.name);
-      if (row) rows.push(row);
-    } else if (entry.isFile() && entry.name.endsWith(".wasm")) {
-      const stem = entry.name.slice(0, -".wasm".length);
-      const size = statSync(entryPath).size;
-      rows.push({ name: stem, version: "—", size });
+  if (existsSync(ORACLE_PLUGIN_DIR)) {
+    const entries = readdirSync(ORACLE_PLUGIN_DIR, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = join(ORACLE_PLUGIN_DIR, entry.name);
+      if (entry.isDirectory()) {
+        const row = readDirPlugin(entryPath, entry.name);
+        if (row) rows.push(row);
+      } else if (entry.isFile() && entry.name.endsWith(".wasm")) {
+        const stem = entry.name.slice(0, -".wasm".length);
+        const size = statSync(entryPath).size;
+        rows.push({ name: stem, version: "—", size });
+      }
     }
-  }
-
-  if (rows.length === 0) {
-    console.log("no plugins installed");
-    return 0;
   }
 
   rows.sort((a, b) => a.name.localeCompare(b.name));
 
-  const nameW = Math.max(4, ...rows.map(r => r.name.length));
-  const verW = Math.max(7, ...rows.map(r => r.version.length));
-  const header = `${"NAME".padEnd(nameW)}  ${"VERSION".padEnd(verW)}  SIZE`;
-  console.log(header);
-  for (const r of rows) {
-    console.log(`${r.name.padEnd(nameW)}  ${r.version.padEnd(verW)}  ${formatSize(r.size)}`);
-  }
+  emit({ dir: ORACLE_PLUGIN_DIR, plugins: rows }, args);
   return 0;
 }

--- a/cli/src/commands/plugins-remove.ts
+++ b/cli/src/commands/plugins-remove.ts
@@ -1,11 +1,12 @@
 import { join } from "path";
 import { homedir } from "os";
 import { existsSync, rmSync, statSync } from "fs";
+import { emit } from "./_output.ts";
 
 const ORACLE_PLUGIN_DIR = join(homedir(), ".oracle", "plugins");
 
 async function confirm(prompt: string): Promise<boolean> {
-  process.stdout.write(prompt);
+  process.stderr.write(prompt);
   for await (const chunk of Bun.stdin.stream()) {
     const input = new TextDecoder().decode(chunk).trim().toLowerCase();
     return input === "y" || input === "yes";
@@ -44,12 +45,12 @@ export async function pluginsRemove(args: string[]): Promise<number> {
   if (!yes) {
     const ok = await confirm(`Remove ${kind} ${target}? [y/N] `);
     if (!ok) {
-      console.log("aborted");
+      emit({ removed: false, aborted: true, target, kind }, args);
       return 1;
     }
   }
 
   rmSync(target, { recursive: true, force: true });
-  console.log(`✓ removed ${kind}: ${target}`);
+  emit({ removed: true, target, kind }, args);
   return 0;
 }

--- a/cli/src/commands/session-context.ts
+++ b/cli/src/commands/session-context.ts
@@ -1,39 +1,10 @@
 import { sessionFetch } from "./session-api.ts";
-
-function fmtTime(v: unknown): string {
-  if (!v) return "—";
-  const s = String(v);
-  const d = new Date(s);
-  if (Number.isNaN(d.getTime())) return s;
-  return d.toISOString().replace("T", " ").slice(0, 19);
-}
-
-function preview(s: unknown, n = 100): string {
-  if (s == null) return "";
-  return String(s).replace(/\s+/g, " ").slice(0, n);
-}
-
-function printSection(title: string, items: any[], previewKeys: string[]) {
-  console.log(`\n── ${title} (${items.length}) ──`);
-  if (items.length === 0) {
-    console.log("  (none)");
-    return;
-  }
-  for (const item of items) {
-    const id = item.id ?? item.thread_id ?? item.trace_id ?? "—";
-    const when = fmtTime(item.created_at ?? item.createdAt ?? item.updated_at ?? item.timestamp);
-    const body = previewKeys.map(k => item[k]).find(v => v != null);
-    console.log(`  [${id}] ${when}`);
-    const p = preview(body);
-    if (p) console.log(`    ${p}`);
-  }
-}
+import { emit } from "./_output.ts";
 
 export async function sessionContext(args: string[]): Promise<number> {
-  const json = args.includes("--json");
   const id = args.find(a => !a.startsWith("-"));
   if (!id) {
-    console.error("usage: arra-cli session context <id> [--json]");
+    console.error("usage: arra-cli session context <id> [--yml]");
     return 1;
   }
 
@@ -53,24 +24,6 @@ export async function sessionContext(args: string[]): Promise<number> {
   }
 
   const data = (await res.json()) as any;
-
-  if (json) {
-    console.log(JSON.stringify(data, null, 2));
-    return 0;
-  }
-
-  const session = data.session ?? data;
-  const threads: any[] = data.threads ?? session.threads ?? [];
-  const learnings: any[] = data.learnings ?? session.learnings ?? [];
-  const traces: any[] = data.traces ?? session.traces ?? [];
-
-  console.log(`session:   ${session.id ?? session.session_id ?? id}`);
-  console.log(`oracle:    ${session.oracle ?? session.agent ?? "—"}`);
-  console.log(`started:   ${fmtTime(session.started_at ?? session.startedAt ?? session.created_at)}`);
-  console.log(`ended:     ${fmtTime(session.ended_at ?? session.endedAt ?? session.last_seen)}`);
-
-  printSection("threads", threads, ["title", "subject", "content", "preview"]);
-  printSection("learnings", learnings, ["content", "pattern", "text", "preview"]);
-  printSection("traces", traces, ["content", "message", "text", "preview"]);
+  emit(data, args);
   return 0;
 }

--- a/cli/src/commands/session-list.ts
+++ b/cli/src/commands/session-list.ts
@@ -1,14 +1,7 @@
 import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
 
-function fmtTime(v: unknown): string {
-  if (!v) return "—";
-  const s = String(v);
-  const d = new Date(s);
-  if (Number.isNaN(d.getTime())) return s;
-  return d.toISOString().replace("T", " ").slice(0, 19);
-}
-
-export async function sessionList(_args: string[]): Promise<number> {
+export async function sessionList(args: string[]): Promise<number> {
   let res: Response;
   try {
     res = await sessionFetch("/api/sessions");
@@ -27,48 +20,6 @@ export async function sessionList(_args: string[]): Promise<number> {
   const data = (await res.json()) as any;
   const sessions: any[] = data.sessions ?? data.results ?? (Array.isArray(data) ? data : []);
 
-  if (sessions.length === 0) {
-    console.log(`no sessions (${sessionApiBase()})`);
-    return 0;
-  }
-
-  type Row = {
-    id: string;
-    oracle: string;
-    lastSeen: string;
-    threads: string;
-    learnings: string;
-    traces: string;
-  };
-
-  const rows: Row[] = sessions.map(s => ({
-    id: String(s.id ?? s.session_id ?? s.sessionId ?? "—"),
-    oracle: String(s.oracle ?? s.agent ?? "—"),
-    lastSeen: fmtTime(s.last_seen ?? s.lastSeen ?? s.updated_at ?? s.ended_at),
-    threads: String(s.threads_count ?? s.threads ?? s.counts?.threads ?? 0),
-    learnings: String(s.learnings_count ?? s.learnings ?? s.counts?.learnings ?? 0),
-    traces: String(s.traces_count ?? s.traces ?? s.counts?.traces ?? 0),
-  }));
-
-  const cols = [
-    { key: "id", head: "SESSION_ID" },
-    { key: "oracle", head: "ORACLE" },
-    { key: "lastSeen", head: "LAST_SEEN" },
-    { key: "threads", head: "#THREADS" },
-    { key: "learnings", head: "#LEARNINGS" },
-    { key: "traces", head: "#TRACES" },
-  ] as const;
-
-  const widths = cols.map(c =>
-    Math.max(c.head.length, ...rows.map(r => (r[c.key as keyof Row] ?? "").length)),
-  );
-
-  const line = (vals: string[]) =>
-    vals.map((v, i) => v.padEnd(widths[i])).join("  ").trimEnd();
-
-  console.log(line(cols.map(c => c.head)));
-  for (const r of rows) {
-    console.log(line(cols.map(c => r[c.key as keyof Row])));
-  }
+  emit({ api: sessionApiBase(), sessions }, args);
   return 0;
 }

--- a/cli/src/commands/session-show.ts
+++ b/cli/src/commands/session-show.ts
@@ -1,12 +1,5 @@
 import { sessionFetch } from "./session-api.ts";
-
-function fmtTime(v: unknown): string {
-  if (!v) return "—";
-  const s = String(v);
-  const d = new Date(s);
-  if (Number.isNaN(d.getTime())) return s;
-  return d.toISOString().replace("T", " ").slice(0, 19);
-}
+import { emit } from "./_output.ts";
 
 function pickCount(s: any, ...keys: string[]): number {
   for (const k of keys) {
@@ -49,13 +42,18 @@ export async function sessionShow(args: string[]): Promise<number> {
   const learningsN = Array.isArray(learnings) ? learnings.length : pickCount(session, "learnings_count", "learnings");
   const tracesN = Array.isArray(traces) ? traces.length : pickCount(session, "traces_count", "traces");
 
-  console.log(`session:   ${session.id ?? session.session_id ?? id}`);
-  console.log(`oracle:    ${session.oracle ?? session.agent ?? "—"}`);
-  console.log(`started:   ${fmtTime(session.started_at ?? session.startedAt ?? session.created_at)}`);
-  console.log(`ended:     ${fmtTime(session.ended_at ?? session.endedAt ?? session.last_seen)}`);
-  console.log("");
-  console.log(`threads:   ${threadsN}`);
-  console.log(`learnings: ${learningsN}`);
-  console.log(`traces:    ${tracesN}`);
+  emit({
+    session: {
+      id: session.id ?? session.session_id ?? id,
+      oracle: session.oracle ?? session.agent ?? null,
+      started_at: session.started_at ?? session.startedAt ?? session.created_at ?? null,
+      ended_at: session.ended_at ?? session.endedAt ?? session.last_seen ?? null,
+    },
+    counts: {
+      threads: threadsN,
+      learnings: learningsN,
+      traces: tracesN,
+    },
+  }, args);
   return 0;
 }


### PR DESCRIPTION
## Summary
- All `arra-cli` commands now default to JSON output — machine-readable by default, human-readable on opt-in
- New `--yml` / `--yaml` flag emits YAML via `Bun.YAML.stringify`
- Shared helper `cli/src/commands/_output.ts` exposes `emit(data, args)` used by every command
- Side-fix: the `plugin` subcommand router was dead-coded for `list`/`info`/`remove`; now wired up so they actually run
- Install-command progress messages moved to stderr so stdout stays pure JSON/YAML

## Affected commands
- `plugin list` — was table → JSON/YAML `{dir, plugins: [...]}`
- `plugin info <name>` — was block → JSON/YAML `{name, manifest, artifact}`
- `plugin install` — was OK banner → JSON/YAML `InstallResult`; status chatter to stderr
- `plugin remove` — was OK banner → JSON/YAML `{removed, target, kind}`
- `session list` — was table → JSON/YAML `{api, sessions}`
- `session show <id>` — was block → JSON/YAML `{session, counts}`
- `session context <id>` — was `--json` opt-in → JSON is now default; `--json` removed in favor of `--yml`

## Test plan
- [x] `bun run build` passes (tsc --noEmit)
- [x] `arra-cli plugin list` emits JSON
- [x] `arra-cli plugin list --yml` emits YAML
- [ ] Other commands verified against a running API

🤖 Generated with [Claude Code](https://claude.com/claude-code)