### PR TITLE
docs: swagger deployment options + export script

### DIFF
--- a/docs/SWAGGER-DEPLOY.md
+++ b/docs/SWAGGER-DEPLOY.md
@@ -1,0 +1,261 @@
+# Deploying `/swagger` Publicly
+
+The Elysia server ships a Scalar UI at `http://localhost:47778/swagger` and
+the raw spec at `http://localhost:47778/swagger/json`. This doc describes
+how to expose that documentation to the public internet without leaking the
+oracle's private HTTP API.
+
+> Status: **not yet deployed.** This is a choose-your-path reference.
+
+## TL;DR
+
+1. Run `bun scripts/export-openapi.ts` to produce `docs/openapi.json`.
+2. Pick one of the three options below. **Option B (static Scalar on CF
+   Workers) is the recommended path.**
+3. Update the CI / release flow to re-run the export on every API change.
+
+---
+
+## Export the spec
+
+`scripts/export-openapi.ts`:
+
+- boots `bun src/server.ts` on a scratch port (default `48900`),
+- polls `/` until the server is ready,
+- fetches `/swagger/json`,
+- validates `openapi` starts with `3.`, `info.title`, `info.version`, and
+  `paths` exist,
+- writes pretty-printed JSON to `docs/openapi.json`,
+- kills the subprocess on success, failure, or SIGINT/SIGTERM.
+
+```bash
+bun scripts/export-openapi.ts
+# → ✓ wrote /…/docs/openapi.json
+#     openapi: 3.1.0
+#     title:   Arra Oracle API
+#     paths:   NN
+```
+
+Flags: `--port <n>` (default `48900`), `--out <path>` (default
+`docs/openapi.json`).
+
+The script does not require a build step — it runs the TypeScript server
+directly via Bun.
+
+---
+
+## Option A — Proxy `/swagger` through studio.buildwithoracle.com
+
+Forward `/swagger` and `/swagger/json` on the public studio host straight
+to the Oracle HTTP API.
+
+### Pros
+- Always live, always matches the running server.
+- No extra build/publish step; new routes show up immediately.
+
+### Cons
+- **Requires backend access on `studio.buildwithoracle.com`** — not always
+  available in the current dev fleet.
+- Exposes a live API surface to the internet even if only the docs are
+  linked. The proxy must be locked down to `GET /swagger*` only.
+- Couples studio uptime to oracle uptime.
+
+### Sketch (Caddyfile)
+
+```caddy
+studio.buildwithoracle.com {
+  @swagger path /swagger /swagger/* /swagger/json
+  reverse_proxy @swagger http://oracle-world.wg:47778 {
+    header_up Host oracle-world.wg
+  }
+
+  # Everything else → studio app
+  reverse_proxy http://127.0.0.1:3000
+}
+```
+
+### Sketch (Cloudflare Workers, fetch-style)
+
+```ts
+export default {
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    if (req.method === 'GET' && url.pathname.startsWith('/swagger')) {
+      const upstream = new URL(url.pathname + url.search, 'https://oracle.internal');
+      return fetch(upstream, { headers: req.headers });
+    }
+    return new Response('not found', { status: 404 });
+  },
+};
+```
+
+Use this when the oracle host is reachable from studio's network (WireGuard
+tunnel, internal Cloudflare Tunnel, etc.). Reject any method other than
+`GET` at the proxy.
+
+---
+
+## Option B — Static export + Scalar on Cloudflare Workers (recommended)
+
+Serve `docs/openapi.json` and a Scalar HTML shell as a static site on a
+Worker. Nothing of the live server is exposed.
+
+### Pros
+- No backend access needed.
+- Cheap, fast, cached at the edge.
+- Docs site is a pure artifact of the repo; previewable per-PR.
+- Matches the house rule: **CF Workers, not Pages** (use `wrangler deploy`
+  with `assets.directory`, never `wrangler pages`).
+
+### Cons
+- Requires re-running the export on every API change.
+- Docs drift if the export is skipped; guard with CI.
+
+### Layout
+
+```
+docs/
+├── openapi.json          # generated
+└── site/
+    ├── index.html        # Scalar UI shell
+    └── _headers          # optional CF headers
+```
+
+`docs/site/index.html`:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Arra Oracle API</title>
+  </head>
+  <body>
+    <script
+      id="api-reference"
+      data-url="/openapi.json"
+      data-proxy-url=""
+    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+  </body>
+</html>
+```
+
+Prefer pinning a Scalar version (e.g. `@scalar/api-reference@1`) in
+production.
+
+### `wrangler.json`
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/cloudflare/workers-sdk/main/packages/wrangler/config-schema.json",
+  "name": "arra-oracle-docs",
+  "compatibility_date": "2026-04-19",
+  "main": "docs/worker.ts",
+  "assets": {
+    "directory": "docs/",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application"
+  },
+  "routes": [
+    { "pattern": "docs.buildwithoracle.com", "custom_domain": true }
+  ],
+  "observability": { "enabled": true }
+}
+```
+
+Minimal `docs/worker.ts` (optional — Workers-only assets works without a
+worker, but this keeps a place to add redirects/headers later):
+
+```ts
+export interface Env { ASSETS: Fetcher }
+
+export default {
+  async fetch(req: Request, env: Env): Promise<Response> {
+    const url = new URL(req.url);
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      return env.ASSETS.fetch(new Request(new URL('/site/index.html', url), req));
+    }
+    return env.ASSETS.fetch(req);
+  },
+};
+```
+
+### Deploy (not executed)
+
+```bash
+bun scripts/export-openapi.ts
+wrangler deploy
+```
+
+### Alternative UI: Redoc
+
+Swap the Scalar shell for Redoc if you prefer its layout:
+
+```html
+<redoc spec-url="/openapi.json"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"></script>
+```
+
+Everything else (wrangler config, export script) is unchanged.
+
+---
+
+## Option C — GitHub Pages
+
+Drop the same `docs/openapi.json` + Scalar HTML into a `gh-pages` branch
+(or the `docs/` folder on main with Pages configured to serve from it).
+
+### Pros
+- Zero infra: repo settings + an Action.
+- Free, versioned alongside source.
+
+### Cons
+- URL lives under `github.io` unless a custom domain is wired up.
+- Pages is a separate publish target from the CF Workers used elsewhere in
+  the fleet — adds a deploy surface.
+
+### Sketch (`.github/workflows/docs.yml`)
+
+```yaml
+name: docs
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/routes/**'
+      - 'src/server.ts'
+      - 'scripts/export-openapi.ts'
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun scripts/export-openapi.ts
+      - run: cp docs/site/index.html docs/index.html
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: docs }
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: { name: github-pages, url: "${{ steps.d.outputs.page_url }}" }
+    steps:
+      - id: d
+        uses: actions/deploy-pages@v4
+```
+
+---
+
+## Recommendation
+
+Go with **Option B**. It matches the CF Workers house rule, needs no
+studio backend access, and keeps the public surface to a pure static
+artifact. Run `bun scripts/export-openapi.ts` in CI on any change to
+`src/routes/**` or `src/server.ts` so the docs never drift.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1,0 +1,1692 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Arra Oracle API",
+    "description": "HTTP API for the Arra Oracle MCP memory layer.",
+    "version": "26.4.19-alpha.9"
+  },
+  "paths": {
+    "/": {
+      "get": {
+        "operationId": "getIndex",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/auth/status": {
+      "get": {
+        "operationId": "getApiAuthStatus",
+        "tags": [
+          "auth",
+          "nav:hidden"
+        ],
+        "summary": "Current auth + session state",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "parameters": [],
+        "operationId": "postApiAuthLogin",
+        "tags": [
+          "auth",
+          "nav:hidden"
+        ],
+        "summary": "Authenticate with password",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "password": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "operationId": "postApiAuthLogout",
+        "tags": [
+          "auth",
+          "nav:hidden"
+        ],
+        "summary": "Clear session cookie",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/settings/": {
+      "get": {
+        "operationId": "getApiSettings",
+        "tags": [
+          "settings",
+          "nav:hidden"
+        ],
+        "summary": "Read oracle settings",
+        "responses": {
+          "200": {}
+        }
+      },
+      "post": {
+        "parameters": [],
+        "operationId": "postApiSettings",
+        "tags": [
+          "settings",
+          "nav:hidden"
+        ],
+        "summary": "Update oracle settings",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string"
+                  },
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "removePassword": {
+                    "type": "boolean"
+                  },
+                  "authEnabled": {
+                    "type": "boolean"
+                  },
+                  "localBypass": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string"
+                  },
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "removePassword": {
+                    "type": "boolean"
+                  },
+                  "authEnabled": {
+                    "type": "boolean"
+                  },
+                  "localBypass": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "newPassword": {
+                    "type": "string"
+                  },
+                  "currentPassword": {
+                    "type": "string"
+                  },
+                  "removePassword": {
+                    "type": "boolean"
+                  },
+                  "authEnabled": {
+                    "type": "boolean"
+                  },
+                  "localBypass": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/feed/": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "oracle",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "event",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "since",
+            "required": false
+          }
+        ],
+        "operationId": "getApiFeed",
+        "tags": [
+          "feed",
+          "nav:hidden"
+        ],
+        "summary": "Merged local + maw-js feed events",
+        "responses": {
+          "200": {}
+        }
+      },
+      "post": {
+        "parameters": [],
+        "operationId": "postApiFeed",
+        "tags": [
+          "feed",
+          "nav:hidden"
+        ],
+        "summary": "Append a feed event",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "oracle": {
+                    "type": "string"
+                  },
+                  "event": {
+                    "type": "string"
+                  },
+                  "project": {
+                    "type": "string"
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "oracle": {
+                    "type": "string"
+                  },
+                  "event": {
+                    "type": "string"
+                  },
+                  "project": {
+                    "type": "string"
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "oracle": {
+                    "type": "string"
+                  },
+                  "event": {
+                    "type": "string"
+                  },
+                  "project": {
+                    "type": "string"
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "message": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/health": {
+      "get": {
+        "operationId": "getApiHealth",
+        "tags": [
+          "health",
+          "nav:hidden"
+        ],
+        "summary": "Server liveness check",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/stats": {
+      "get": {
+        "operationId": "getApiStats",
+        "tags": [
+          "health",
+          "nav:tools",
+          "order:50"
+        ],
+        "summary": "Database and vector stats",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/oracles": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "hours",
+            "required": false
+          }
+        ],
+        "operationId": "getApiOracles",
+        "tags": [
+          "health",
+          "nav:hidden"
+        ],
+        "summary": "Oracle identities + project activity",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/dashboard": {
+      "get": {
+        "operationId": "getApiDashboard",
+        "tags": [
+          "dashboard",
+          "nav:hidden"
+        ],
+        "summary": "Dashboard summary",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/dashboard/summary": {
+      "get": {
+        "operationId": "getApiDashboardSummary",
+        "tags": [
+          "dashboard",
+          "nav:hidden"
+        ],
+        "summary": "Dashboard summary (alias)",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/dashboard/activity": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "days",
+            "required": false
+          }
+        ],
+        "operationId": "getApiDashboardActivity",
+        "tags": [
+          "dashboard",
+          "nav:hidden"
+        ],
+        "summary": "Activity counts over N days",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/dashboard/growth": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "period",
+            "required": false
+          }
+        ],
+        "operationId": "getApiDashboardGrowth",
+        "tags": [
+          "dashboard",
+          "nav:hidden"
+        ],
+        "summary": "Growth over a period",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/session/stats": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "since",
+            "required": false
+          }
+        ],
+        "operationId": "getApiSessionStats",
+        "tags": [
+          "dashboard",
+          "nav:hidden"
+        ],
+        "summary": "Session-level search + learn counts",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/search": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "q",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "mode",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "project",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "cwd",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "model",
+            "required": false
+          }
+        ],
+        "operationId": "getApiSearch",
+        "tags": [
+          "search",
+          "nav:main",
+          "order:10"
+        ],
+        "summary": "Hybrid search over oracle docs",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/reflect": {
+      "get": {
+        "operationId": "getApiReflect",
+        "tags": [
+          "search",
+          "nav:main",
+          "order:30"
+        ],
+        "summary": "Oracle self-reflection snapshot",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/similar": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "id",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "model",
+            "required": false
+          }
+        ],
+        "operationId": "getApiSimilar",
+        "tags": [
+          "search",
+          "nav:hidden"
+        ],
+        "summary": "Vector nearest-neighbor lookup by doc id",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/map": {
+      "get": {
+        "operationId": "getApiMap",
+        "tags": [
+          "map",
+          "nav:tools",
+          "order:20"
+        ],
+        "summary": "2D projection of embeddings",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/map3d": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "model",
+            "required": false
+          }
+        ],
+        "operationId": "getApiMap3d",
+        "tags": [
+          "map",
+          "nav:tools",
+          "order:30"
+        ],
+        "summary": "3D PCA projection of embeddings",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/list": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "group",
+            "required": false
+          }
+        ],
+        "operationId": "getApiList",
+        "tags": [
+          "search",
+          "nav:main",
+          "order:20"
+        ],
+        "summary": "List oracle documents",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/learn": {
+      "post": {
+        "parameters": [],
+        "operationId": "postApiLearn",
+        "tags": [
+          "knowledge",
+          "nav:hidden"
+        ],
+        "summary": "Record a learning pattern",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/handoff": {
+      "post": {
+        "parameters": [],
+        "operationId": "postApiHandoff",
+        "tags": [
+          "knowledge",
+          "nav:hidden"
+        ],
+        "summary": "Write a handoff markdown file",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/inbox": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "type",
+            "required": false
+          }
+        ],
+        "operationId": "getApiInbox",
+        "tags": [
+          "knowledge",
+          "nav:hidden"
+        ],
+        "summary": "List inbox handoff files",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/supersede": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "project",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          }
+        ],
+        "operationId": "getApiSupersede",
+        "tags": [
+          "supersede",
+          "nav:tools",
+          "order:60"
+        ],
+        "summary": "List superseded documents",
+        "responses": {
+          "200": {}
+        }
+      },
+      "post": {
+        "parameters": [],
+        "operationId": "postApiSupersede",
+        "tags": [
+          "supersede",
+          "nav:hidden"
+        ],
+        "summary": "Append to legacy supersede_log",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/supersede/chain/{path}": {
+      "get": {
+        "operationId": "getApiSupersedeChainByPath",
+        "tags": [
+          "supersede",
+          "nav:tools",
+          "order:70"
+        ],
+        "summary": "Supersession chain for a doc path",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/threads": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          }
+        ],
+        "operationId": "getApiThreads",
+        "tags": [
+          "forum",
+          "nav:main",
+          "order:40"
+        ],
+        "summary": "List forum threads",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/thread": {
+      "post": {
+        "parameters": [],
+        "operationId": "postApiThread",
+        "tags": [
+          "forum",
+          "nav:hidden"
+        ],
+        "summary": "Post a message to a forum thread",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/thread/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "getApiThreadById",
+        "tags": [
+          "forum",
+          "nav:hidden"
+        ],
+        "summary": "Get one forum thread",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/thread/{id}/status": {
+      "patch": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "patchApiThreadByIdStatus",
+        "tags": [
+          "forum",
+          "nav:hidden"
+        ],
+        "summary": "Update a thread status",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "query",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "project",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "offset",
+            "required": false
+          }
+        ],
+        "operationId": "getApiTraces",
+        "tags": [
+          "traces",
+          "nav:main",
+          "order:50"
+        ],
+        "summary": "List traces",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "getApiTracesById",
+        "tags": [
+          "traces",
+          "nav:hidden"
+        ],
+        "summary": "Get a single trace",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces/{id}/chain": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "direction",
+            "required": false
+          }
+        ],
+        "operationId": "getApiTracesByIdChain",
+        "tags": [
+          "traces",
+          "nav:hidden"
+        ],
+        "summary": "Get causal chain for a trace",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces/{prevId}/link": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "prevId",
+            "required": true
+          }
+        ],
+        "operationId": "postApiTracesByPrevIdLink",
+        "tags": [
+          "traces",
+          "nav:hidden"
+        ],
+        "summary": "Link two traces",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces/{id}/link": {
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "direction",
+            "required": false
+          }
+        ],
+        "operationId": "deleteApiTracesByIdLink",
+        "tags": [
+          "traces",
+          "nav:hidden"
+        ],
+        "summary": "Unlink traces in a direction",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/traces/{id}/linked-chain": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "getApiTracesByIdLinked-chain",
+        "tags": [
+          "traces",
+          "nav:hidden"
+        ],
+        "summary": "Walk explicit trace link graph",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/schedule/md": {
+      "get": {
+        "operationId": "getApiScheduleMd",
+        "tags": [
+          "schedule",
+          "nav:hidden"
+        ],
+        "summary": "Raw schedule markdown",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/schedule": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "date",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "from",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "to",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "filter",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "status",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "operationId": "getApiSchedule",
+        "tags": [
+          "schedule",
+          "nav:main",
+          "order:60"
+        ],
+        "summary": "List scheduled events",
+        "responses": {
+          "200": {}
+        }
+      },
+      "post": {
+        "parameters": [],
+        "operationId": "postApiSchedule",
+        "tags": [
+          "schedule",
+          "nav:hidden"
+        ],
+        "summary": "Create a schedule entry",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/schedule/{id}": {
+      "patch": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "patchApiScheduleById",
+        "tags": [
+          "schedule",
+          "nav:hidden"
+        ],
+        "summary": "Update a schedule entry",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {}
+            },
+            "multipart/form-data": {
+              "schema": {}
+            },
+            "text/plain": {
+              "schema": {}
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/graph": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "operationId": "getApiGraph",
+        "tags": [
+          "files",
+          "nav:tools",
+          "order:10"
+        ],
+        "summary": "Graph visualization data",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/context": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "cwd",
+            "required": false
+          }
+        ],
+        "operationId": "getApiContext",
+        "tags": [
+          "files",
+          "nav:tools",
+          "order:40"
+        ],
+        "summary": "Context for a working directory",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/file": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Repo- or project-relative path. No \"..\", no null-byte.",
+            "schema": {
+              "type": "string",
+              "pattern": "^(?!.*\\.\\.)(?!.*\\x00).*$"
+            },
+            "in": "query",
+            "name": "path",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "project",
+            "required": false
+          }
+        ],
+        "operationId": "getApiFile",
+        "tags": [
+          "files",
+          "nav:hidden"
+        ],
+        "summary": "Cross-repo file read with traversal guard",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/read": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "file",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "id",
+            "required": false
+          }
+        ],
+        "operationId": "getApiRead",
+        "tags": [
+          "files",
+          "nav:hidden"
+        ],
+        "summary": "Read a file or doc by id",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/doc/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "getApiDocById",
+        "tags": [
+          "files",
+          "nav:hidden"
+        ],
+        "summary": "Get one oracle document by id",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/logs": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "operationId": "getApiLogs",
+        "tags": [
+          "files",
+          "nav:hidden"
+        ],
+        "summary": "Recent search log entries",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/plugins": {
+      "get": {
+        "operationId": "getApiPlugins",
+        "tags": [
+          "plugins",
+          "nav:main",
+          "order:70"
+        ],
+        "summary": "List available plugins",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/plugins/{name}": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "name",
+            "required": true
+          }
+        ],
+        "operationId": "getApiPluginsByName",
+        "tags": [
+          "plugins",
+          "nav:hidden"
+        ],
+        "summary": "Fetch plugin wasm bytes",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/oraclenet/feed": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "sort",
+            "required": false
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "operationId": "getApiOraclenetFeed",
+        "tags": [
+          "oraclenet",
+          "nav:hidden"
+        ],
+        "summary": "Proxy OracleNet feed records",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/oraclenet/oracles": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "limit",
+            "required": false
+          }
+        ],
+        "operationId": "getApiOraclenetOracles",
+        "tags": [
+          "oraclenet",
+          "nav:hidden"
+        ],
+        "summary": "Proxy OracleNet oracle records",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/oraclenet/presence": {
+      "get": {
+        "operationId": "getApiOraclenetPresence",
+        "tags": [
+          "oraclenet",
+          "nav:hidden"
+        ],
+        "summary": "Active oracle presence heartbeats",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/oraclenet/status": {
+      "get": {
+        "operationId": "getApiOraclenetStatus",
+        "tags": [
+          "oraclenet",
+          "nav:hidden"
+        ],
+        "summary": "OracleNet upstream health",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/api/session/{id}/summary": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "in": "path",
+            "name": "id",
+            "required": true
+          }
+        ],
+        "operationId": "postApiSessionByIdSummary",
+        "tags": [
+          "sessions",
+          "nav:hidden"
+        ],
+        "summary": "Record a session summary",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "summary"
+                ],
+                "properties": {
+                  "summary": {
+                    "type": "string"
+                  },
+                  "oracle": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "summary"
+                ],
+                "properties": {
+                  "summary": {
+                    "type": "string"
+                  },
+                  "oracle": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "summary"
+                ],
+                "properties": {
+                  "summary": {
+                    "type": "string"
+                  },
+                  "oracle": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/scripts/export-openapi.ts
+++ b/scripts/export-openapi.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env bun
+/**
+ * Export the Elysia /swagger/json spec to docs/openapi.json.
+ *
+ * Spawns `bun src/server.ts` on a scratch port, polls until /health
+ * responds, fetches /swagger/json, writes the file, then kills the
+ * subprocess. Exits non-zero on any failure.
+ *
+ *   bun scripts/export-openapi.ts
+ *   bun scripts/export-openapi.ts --port 48900 --out docs/openapi.json
+ */
+
+import { spawn } from 'bun';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+
+const args = parseArgs(process.argv.slice(2));
+const PORT = args.port ?? '48900';
+const OUT = resolve(args.out ?? 'docs/openapi.json');
+const BOOT_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 200;
+
+const child = spawn({
+  cmd: ['bun', 'src/server.ts'],
+  env: { ...process.env, ORACLE_PORT: PORT, NODE_ENV: 'development' },
+  stdout: 'pipe',
+  stderr: 'pipe',
+});
+
+const shutdown = async (code: number): Promise<never> => {
+  try {
+    child.kill('SIGTERM');
+    await Promise.race([
+      child.exited,
+      new Promise((r) => setTimeout(r, 3000)),
+    ]);
+    if (!child.killed) child.kill('SIGKILL');
+  } catch {}
+  process.exit(code);
+};
+
+process.on('SIGINT', () => shutdown(130));
+process.on('SIGTERM', () => shutdown(143));
+
+try {
+  await waitForServer(`http://127.0.0.1:${PORT}/`, BOOT_TIMEOUT_MS);
+
+  const res = await fetch(`http://127.0.0.1:${PORT}/swagger/json`);
+  if (!res.ok) throw new Error(`fetch /swagger/json failed: ${res.status}`);
+  const spec = await res.json();
+
+  validateOpenAPI3(spec);
+
+  await mkdir(dirname(OUT), { recursive: true });
+  await writeFile(OUT, JSON.stringify(spec, null, 2) + '\n', 'utf8');
+
+  console.log(`✓ wrote ${OUT}`);
+  console.log(`  openapi: ${spec.openapi}`);
+  console.log(`  title:   ${spec.info?.title}`);
+  console.log(`  version: ${spec.info?.version}`);
+  console.log(`  paths:   ${Object.keys(spec.paths ?? {}).length}`);
+
+  await shutdown(0);
+} catch (err) {
+  console.error('✗ export-openapi failed:', err instanceof Error ? err.message : err);
+  await shutdown(1);
+}
+
+function parseArgs(argv: string[]): { port?: string; out?: string } {
+  const out: { port?: string; out?: string } = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--port') out.port = argv[++i];
+    else if (a === '--out') out.out = argv[++i];
+  }
+  return out;
+}
+
+async function waitForServer(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(url);
+      if (r.ok) return;
+    } catch {}
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`server did not become ready on ${url} within ${timeoutMs}ms`);
+}
+
+function validateOpenAPI3(spec: any): void {
+  if (!spec || typeof spec !== 'object') throw new Error('spec is not an object');
+  if (typeof spec.openapi !== 'string' || !spec.openapi.startsWith('3.'))
+    throw new Error(`openapi field must start with "3.", got ${JSON.stringify(spec.openapi)}`);
+  if (!spec.info || typeof spec.info.title !== 'string' || typeof spec.info.version !== 'string')
+    throw new Error('info.title and info.version are required');
+  if (!spec.paths || typeof spec.paths !== 'object')
+    throw new Error('paths object is required');
+}


### PR DESCRIPTION
## Summary
- `scripts/export-openapi.ts` — boots the server on a scratch port, fetches `/swagger/json`, validates openapi 3.x / info / paths, writes `docs/openapi.json`, then shuts the subprocess down.
- `docs/SWAGGER-DEPLOY.md` — three deployment options (studio proxy / static Scalar on CF Workers / GitHub Pages) with a concrete `wrangler.json` and a Redoc alternative.
- `docs/openapi.json` — generated snapshot (3.0.3, 51 paths).

Option B (CF Workers static) is the recommended path: no backend access required and matches the house rule of Workers over Pages.

## Test plan
- [x] `bun scripts/export-openapi.ts` succeeds, prints `openapi: 3.0.3`, 51 paths
- [x] `jq -r '.openapi' docs/openapi.json` → `3.0.3`
- [x] Script honors `--port` and `--out` flags (parsed in `parseArgs`)
- [x] Subprocess is reaped on success, failure, and SIGINT/SIGTERM
- [x] No changes to `src/server.ts` or any route module

🤖 Generated with [Claude Code](https://claude.com/claude-code)