### PR TITLE
feat(menu): src/menu/ frontend page declarations (#903)

### DIFF
--- a/src/menu/frontend.ts
+++ b/src/menu/frontend.ts
@@ -1,0 +1,11 @@
+import type { MenuItem } from './types.ts';
+
+const items: MenuItem[] = [
+  { path: '/canvas', label: 'Canvas', group: 'tools', order: 80, source: 'frontend' },
+  { path: '/playground', label: 'Playground', group: 'tools', order: 81, source: 'frontend' },
+  { path: '/compare', label: 'Compare', group: 'tools', order: 82, source: 'frontend' },
+  { path: '/evolution', label: 'Evolution', group: 'tools', order: 83, source: 'frontend' },
+  { path: '/settings', label: 'Settings', group: 'hidden', order: 99, source: 'frontend' },
+];
+
+export default items;

--- a/src/menu/index.ts
+++ b/src/menu/index.ts
@@ -1,0 +1,8 @@
+import frontend from './frontend.ts';
+import type { MenuItem } from './types.ts';
+
+export type { MenuItem };
+
+export function getFrontendMenuItems(): MenuItem[] {
+  return [...frontend];
+}

--- a/src/menu/types.ts
+++ b/src/menu/types.ts
@@ -1,0 +1,7 @@
+export interface MenuItem {
+  path: string;
+  label: string;
+  group: string;
+  order: number;
+  source: 'frontend' | 'api' | 'plugin';
+}


### PR DESCRIPTION
## Summary
- Phase B of hook_menu (parent #901, issue #903)
- Adds `src/menu/` for frontend-only pages without API routes:
  - `/canvas`, `/playground`, `/compare`, `/evolution` (group: `tools`)
  - `/settings` (group: `hidden`)
- Files:
  - `src/menu/types.ts` — `MenuItem` shape
  - `src/menu/frontend.ts` — default-exported `MenuItem[]`
  - `src/menu/index.ts` — `getFrontendMenuItems()` loader (explicit imports; ≤5 files, no need for `import.meta.glob`)

## Dependency
Depends on #902 (red — Phase A `/api/menu` aggregator).
**Merge after #902.** Once landed, wire `getFrontendMenuItems()` into `src/routes/menu/menu.ts` aggregator alongside the swagger-tag source.

## Test plan
- [ ] After #902 merge, import `getFrontendMenuItems()` in aggregator and verify items appear in `/api/menu` response
- [ ] Confirm no path collisions with API routes (Settings is in `hidden` group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)