### PR TITLE
feat(plugins): support menu field in plugin.json (#904)

### DIFF
--- a/cli/src/plugins/hello/plugin.json
+++ b/cli/src/plugins/hello/plugin.json
@@ -6,5 +6,11 @@
   "cli": {
     "command": "hello",
     "help": "arra-cli hello — sample plugin"
+  },
+  "menu": {
+    "label": "Hello",
+    "group": "tools",
+    "order": 100,
+    "icon": "wave"
   }
 }

--- a/docs/PLUGIN-MENU.md
+++ b/docs/PLUGIN-MENU.md
@@ -1,0 +1,87 @@
+# Plugin Menu Items
+
+Plugins can contribute entries to the Oracle navigation menu by adding an optional
+`menu` field to their `plugin.json` manifest. The scanner that backs `/api/plugins`
+reads this field and the `/api/menu` aggregator (#902) merges it with menu items
+from swagger tags and `src/menu/*.ts` autoloaded pages.
+
+## Schema
+
+```jsonc
+{
+  "name": "my-plugin",
+  "version": "1.0.0",
+  "wasm": "my-plugin.wasm",
+  "menu": {
+    "label": "My Plugin",        // required — shown in the menu
+    "group": "tools",             // optional — "main" | "tools" | "hidden" (default "tools")
+    "order": 100,                 // optional — sort key, lower first (default 999)
+    "icon": "sparkles",           // optional — icon identifier
+    "path": "/plugins/my-plugin"  // optional — override; default is "/plugins/<name>"
+  }
+}
+```
+
+All fields except `label` are optional. Invalid or unrecognized values fall back
+to the defaults.
+
+## Example
+
+```json
+{
+  "name": "hello",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "cli": {
+    "command": "hello",
+    "help": "arra-cli hello — sample plugin"
+  },
+  "menu": {
+    "label": "Hello",
+    "group": "tools",
+    "order": 100,
+    "icon": "wave"
+  }
+}
+```
+
+The aggregated menu item emitted for this plugin looks like:
+
+```json
+{
+  "label": "Hello",
+  "path": "/plugins/hello",
+  "group": "tools",
+  "order": 100,
+  "icon": "wave",
+  "source": "plugin",
+  "sourceName": "hello"
+}
+```
+
+## How to consume
+
+Server code can import the helper directly:
+
+```ts
+import { getPluginMenuItems } from './routes/plugins/model.ts';
+
+const items = getPluginMenuItems();
+```
+
+The `/api/menu` aggregator consumes this helper and merges the result with the
+other menu sources.
+
+## Groups
+
+- `main` — top-level navigation
+- `tools` — utilities / secondary menu (default)
+- `hidden` — registered but not displayed; useful for deep-link routes
+
+## Related
+
+- `#902` — `/api/menu` aggregator (red, Phase A)
+- `#903` — `src/menu/*.ts` autoload for frontend pages (orange, Phase B)
+- `#904` — this change (yellow, Phase C)
+- `#905` — `studio:<domain>` tag support (green, Phase D)

--- a/src/routes/plugins/model.ts
+++ b/src/routes/plugins/model.ts
@@ -5,12 +5,22 @@
  *
  * Logic is identical to src/routes/plugins.ts (the Hono twin, scheduled for
  * removal once the Elysia migration wires up). During transition both exist. */
-import { t } from 'elysia';
+import { t, type Static } from 'elysia';
 import { readdirSync, statSync, readFileSync, existsSync } from 'fs';
 import { join, basename } from 'path';
 import { homedir } from 'os';
 
 export const PLUGIN_DIR = join(homedir(), '.oracle', 'plugins');
+
+export const PluginMenuSchema = t.Object({
+  label: t.String(),
+  group: t.Optional(t.Union([t.Literal('main'), t.Literal('tools'), t.Literal('hidden')])),
+  order: t.Optional(t.Number()),
+  icon: t.Optional(t.String()),
+  path: t.Optional(t.String()),
+});
+
+export type PluginMenu = Static<typeof PluginMenuSchema>;
 
 export type PluginEntry = {
   name: string;
@@ -19,9 +29,32 @@ export type PluginEntry = {
   modified: string;
   version?: string;
   description?: string;
+  menu?: PluginMenu;
+};
+
+export type MenuItem = {
+  label: string;
+  path: string;
+  group: 'main' | 'tools' | 'hidden';
+  order: number;
+  icon?: string;
+  source: 'plugin';
+  sourceName: string;
 };
 
 export const pluginNameParams = t.Object({ name: t.String() });
+
+function parseMenu(raw: unknown): PluginMenu | undefined {
+  if (!raw || typeof raw !== 'object') return undefined;
+  const m = raw as Record<string, unknown>;
+  if (typeof m.label !== 'string' || !m.label) return undefined;
+  const group =
+    m.group === 'main' || m.group === 'tools' || m.group === 'hidden' ? m.group : undefined;
+  const order = typeof m.order === 'number' ? m.order : undefined;
+  const icon = typeof m.icon === 'string' ? m.icon : undefined;
+  const path = typeof m.path === 'string' ? m.path : undefined;
+  return { label: m.label, group, order, icon, path };
+}
 
 export function readNestedPlugin(
   dir: string,
@@ -29,7 +62,13 @@ export function readNestedPlugin(
 ): PluginEntry | null {
   const manifestPath = join(dir, 'plugin.json');
   if (!existsSync(manifestPath)) return null;
-  let manifest: { name?: string; version?: string; description?: string; wasm?: string };
+  let manifest: {
+    name?: string;
+    version?: string;
+    description?: string;
+    wasm?: string;
+    menu?: unknown;
+  };
   try {
     manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
   } catch {
@@ -57,6 +96,7 @@ export function readNestedPlugin(
     modified: st.mtime.toISOString(),
     version: typeof manifest.version === 'string' ? manifest.version : undefined,
     description: typeof manifest.description === 'string' ? manifest.description : undefined,
+    menu: parseMenu(manifest.menu),
   };
 }
 
@@ -109,4 +149,22 @@ export function scanPlugins(): { plugins: PluginEntry[]; dir: string } {
     }
   }
   return { plugins, dir: PLUGIN_DIR };
+}
+
+export function getPluginMenuItems(): MenuItem[] {
+  const { plugins } = scanPlugins();
+  const items: MenuItem[] = [];
+  for (const p of plugins) {
+    if (!p.menu) continue;
+    items.push({
+      label: p.menu.label,
+      path: p.menu.path ?? `/plugins/${p.name}`,
+      group: p.menu.group ?? 'tools',
+      order: p.menu.order ?? 999,
+      icon: p.menu.icon,
+      source: 'plugin',
+      sourceName: p.name,
+    });
+  }
+  return items;
 }


### PR DESCRIPTION
## Summary
- Extend nested `plugin.json` manifest with an optional `menu` field (`label`, `group`, `order`, `icon`, `path`)
- Scanner (`src/routes/plugins/model.ts`) now surfaces `menu` on `PluginEntry`
- New `getPluginMenuItems(): MenuItem[]` helper for the `/api/menu` aggregator (#902)
- Sample plugin (`cli/src/plugins/hello`) gains a menu entry
- `docs/PLUGIN-MENU.md` documents schema + example

Part of parent #901 (hook-menu). Phase C / Task #3.

## Dependencies
- **Blocked on #902 (red, Phase A)** for the `/api/menu` endpoint wiring. `getPluginMenuItems()` is ready to be imported by that aggregator — the wiring commit will land once #902 merges. The helper is exported and tested standalone.
- The external sample plugin repo (`Soul-Brews-Studio/arra-wasm-hello`) should get a menu field in its `plugin.json` in a separate commit; proposing as a follow-up doc PR rather than bundling here.

## Test plan
- [x] `bun -e \"import { getPluginMenuItems } from './src/routes/plugins/model.ts'; console.log(getPluginMenuItems())\"` returns `[]` on empty `~/.oracle/plugins`
- [ ] Install a plugin with a `menu` field → `getPluginMenuItems()` returns one entry with defaults applied
- [ ] Install a plugin without a `menu` field → excluded from result
- [ ] After #902 merges: `/api/menu` response includes plugin-sourced entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)