### PR TITLE
feat(menu): /api/menu endpoint aggregating swagger nav tags (#902)

### DIFF
--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Menu Routes (Elysia) — composes /api/menu.
+ *
+ * The menu endpoint reads swagger nav tags off the other modules' routes,
+ * so it's built via a factory that accepts the sibling modules to inspect.
+ */
+
+import { Elysia } from 'elysia';
+import { createMenuEndpoint } from './menu.ts';
+
+type HasRoutes = { routes: Array<{ path: string; hooks?: { detail?: unknown } }> };
+
+export function createMenuRoutes(sources: HasRoutes[]) {
+  return new Elysia({ prefix: '/api' }).use(createMenuEndpoint(sources));
+}
+
+export { buildMenuItems, API_TO_STUDIO } from './menu.ts';
+export type { MenuItem, MenuResponse } from './model.ts';

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/menu — aggregates navigation from swagger tags on mounted routes.
+ *
+ * Reads `nav:main` / `nav:tools` / `nav:hidden` + optional `order:N` from each
+ * endpoint's `detail.tags`. Maps API prefixes to studio routes using
+ * API_TO_STUDIO (kept in sync with oracle-studio's Header.tsx).
+ */
+
+import { Elysia } from 'elysia';
+import { MenuItemSchema, MenuResponseSchema, type MenuItem } from './model.ts';
+
+export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
+  ['/api/supersede', '/superseded'],
+  ['/api/search', '/search'],
+  ['/api/list', '/feed'],
+  ['/api/reflect', '/playground'],
+  ['/api/threads', '/forum'],
+  ['/api/traces', '/traces'],
+  ['/api/schedule', '/schedule'],
+  ['/api/plugins', '/plugins'],
+  ['/api/graph', '/map'],
+  ['/api/map3d', '/map'],
+  ['/api/map', '/map'],
+  ['/api/context', '/evolution'],
+  ['/api/stats', '/pulse'],
+];
+
+function studioPathFor(apiPath: string): string | null {
+  for (const [prefix, studio] of API_TO_STUDIO) {
+    if (apiPath === prefix || apiPath.startsWith(prefix + '/')) return studio;
+  }
+  return null;
+}
+
+type RouteLike = { method?: string; path: string; hooks?: { detail?: unknown } };
+type HasRoutes = { routes: RouteLike[] };
+
+const GROUP_RANK: Record<MenuItem['group'], number> = { main: 0, tools: 1, hidden: 2 };
+
+export function buildMenuItems(sources: HasRoutes[]): MenuItem[] {
+  const items: MenuItem[] = [];
+  const seen = new Set<string>();
+
+  for (const src of sources) {
+    for (const route of src.routes) {
+      const detail = (route.hooks?.detail ?? {}) as {
+        tags?: unknown;
+        summary?: unknown;
+      };
+      const tags: string[] = Array.isArray(detail.tags)
+        ? (detail.tags as unknown[]).filter((t): t is string => typeof t === 'string')
+        : [];
+
+      const group: MenuItem['group'] | null = tags.includes('nav:main')
+        ? 'main'
+        : tags.includes('nav:tools')
+          ? 'tools'
+          : tags.includes('nav:hidden')
+            ? 'hidden'
+            : null;
+      if (!group) continue;
+
+      const studio = studioPathFor(route.path);
+      if (!studio) continue;
+
+      const key = `${group}:${studio}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      const orderTag = tags.find((t) => t.startsWith('order:'));
+      const parsed = orderTag ? parseInt(orderTag.slice('order:'.length), 10) : NaN;
+      const order = Number.isFinite(parsed) ? parsed : 999;
+
+      const summary = typeof detail.summary === 'string' ? detail.summary : '';
+      const label = summary || studio.replace('/', '') || 'Home';
+
+      items.push({ path: studio, label, group, order, source: 'api' });
+    }
+  }
+
+  items.sort((a, b) => GROUP_RANK[a.group] - GROUP_RANK[b.group] || a.order - b.order);
+  return items;
+}
+
+export function createMenuEndpoint(sources: HasRoutes[]) {
+  return new Elysia().get(
+    '/menu',
+    () => ({ items: buildMenuItems(sources) }),
+    {
+      response: MenuResponseSchema,
+      detail: {
+        tags: ['menu', 'nav:hidden'],
+        summary: 'Aggregated studio navigation from swagger nav tags',
+      },
+    },
+  );
+}
+
+export { MenuItemSchema };

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -1,0 +1,23 @@
+/**
+ * TypeBox schemas for /api/menu.
+ */
+
+import { t } from 'elysia';
+import type { Static } from 'elysia';
+
+export const MenuItemSchema = t.Object({
+  path: t.String(),
+  label: t.String(),
+  group: t.Union([t.Literal('main'), t.Literal('tools'), t.Literal('hidden')]),
+  order: t.Number(),
+  source: t.Union([t.Literal('api'), t.Literal('page'), t.Literal('plugin')]),
+  studio: t.Optional(t.String()),
+});
+
+export type MenuItem = Static<typeof MenuItemSchema>;
+
+export const MenuResponseSchema = t.Object({
+  items: t.Array(MenuItemSchema),
+});
+
+export type MenuResponse = Static<typeof MenuResponseSchema>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,7 @@ import { filesRouter } from './routes/files/index.ts';
 import { pluginsRouter } from './routes/plugins/index.ts';
 import { oraclenetRoutes } from './routes/oraclenet/index.ts';
 import { sessionsRoutes } from './routes/sessions/index.ts';
+import { createMenuRoutes } from './routes/menu/index.ts';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -154,7 +155,7 @@ const app = new Elysia()
     api: '/api',
   }));
 
-const modules = [
+const apiModules = [
   authRoutes,
   settingsRoutes,
   feedRoutes,
@@ -171,6 +172,10 @@ const modules = [
   oraclenetRoutes,
   sessionsRoutes,
 ];
+
+const menuRoutes = createMenuRoutes(apiModules as unknown as Parameters<typeof createMenuRoutes>[0]);
+
+const modules = [...apiModules, menuRoutes];
 
 for (const mod of modules) app.use(mod as any);
 

--- a/tests/http/menu/list.test.ts
+++ b/tests/http/menu/list.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for /api/menu — aggregates nav tags off mounted Elysia routes.
+ *
+ * These exercise the menu builder in isolation with synthetic sub-apps so
+ * they run without a live server. The real server wires `apiModules` into
+ * `createMenuRoutes` in src/server.ts.
+ */
+
+import { describe, test, expect } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createMenuRoutes, buildMenuItems, type MenuItem } from '../../../src/routes/menu/index.ts';
+
+function fakeApiModule() {
+  return new Elysia({ prefix: '/api' })
+    .get('/search', () => ({}), {
+      detail: { tags: ['search', 'nav:main', 'order:10'], summary: 'Search' },
+    })
+    .get('/list', () => ({}), {
+      detail: { tags: ['search', 'nav:main', 'order:20'], summary: 'List oracle documents' },
+    })
+    .get('/map', () => ({}), {
+      detail: { tags: ['map', 'nav:tools', 'order:20'], summary: 'Map 2D' },
+    })
+    .get('/map3d', () => ({}), {
+      detail: { tags: ['map', 'nav:tools', 'order:30'], summary: 'Map 3D' },
+    })
+    .get('/settings', () => ({}), {
+      detail: { tags: ['settings', 'nav:hidden'], summary: 'Settings' },
+    })
+    .get('/untagged', () => ({}), {
+      detail: { tags: ['internal'], summary: 'Internal' },
+    });
+}
+
+describe('/api/menu', () => {
+  test('groups routes into main / tools / hidden', async () => {
+    const app = createMenuRoutes([fakeApiModule()]);
+    const res = await app.handle(new Request('http://localhost/api/menu'));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: MenuItem[] };
+    const groups = new Map<string, MenuItem[]>();
+    for (const item of body.items) {
+      const arr = groups.get(item.group) ?? [];
+      arr.push(item);
+      groups.set(item.group, arr);
+    }
+    const main = groups.get('main') ?? [];
+    const tools = groups.get('tools') ?? [];
+    const hidden = groups.get('hidden') ?? [];
+    expect(main.map((i) => i.path)).toEqual(['/search', '/feed']);
+    expect(tools.map((i) => i.path)).toEqual(['/map']);
+    expect(hidden.length).toBe(0);
+  });
+
+  test('respects order:N tag and studio path dedupe', () => {
+    const sub = fakeApiModule();
+    const items = buildMenuItems([sub]);
+    const main = items.filter((i) => i.group === 'main');
+    const tools = items.filter((i) => i.group === 'tools');
+    expect(main[0]).toMatchObject({ path: '/search', label: 'Search', order: 10, source: 'api' });
+    expect(main[1]).toMatchObject({ path: '/feed', label: 'List oracle documents', order: 20 });
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toMatchObject({ path: '/map', order: 20 });
+  });
+
+  test('unmapped or untagged paths are skipped', () => {
+    const sub = new Elysia({ prefix: '/api' })
+      .get('/unknown', () => ({}), {
+        detail: { tags: ['nav:main', 'order:1'], summary: 'Unknown' },
+      })
+      .get('/plain', () => ({}), {
+        detail: { tags: [], summary: 'plain' },
+      });
+    const items = buildMenuItems([sub]);
+    expect(items).toHaveLength(0);
+  });
+
+  test('menu endpoint self-tags as nav:hidden', () => {
+    const app = createMenuRoutes([]);
+    const menuRoute = app.routes.find((r) => r.path === '/api/menu');
+    expect(menuRoute).toBeDefined();
+    const detail = (menuRoute!.hooks as { detail?: { tags?: string[] } }).detail;
+    expect(detail?.tags).toContain('menu');
+    expect(detail?.tags).toContain('nav:hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- New `src/routes/menu/` module — Elysia sub-app that exposes `GET /api/menu`
- `buildMenuItems()` iterates mounted sub-apps' `routes`, reads `detail.tags` for `nav:main` / `nav:tools` / `nav:hidden` + `order:N`, maps API paths to studio routes via `API_TO_STUDIO` (mirrors `oracle-studio/src/components/Header.tsx`)
- `MenuItem` shape: `{ path, label, group, order, source: 'api', studio? }` — `studio` reserved for Phase D (studio:<domain> tags)
- `/api/menu` self-tags as `['menu', 'nav:hidden']` so studio doesn't render itself in the nav
- Wired into `src/server.ts` modules list (constructed after the API modules so it can see their routes)

Closes part of #901 parent. Phase A — backend aggregation. Studio still reads `/swagger/json` until Phase B/blue swap.

## Test plan
- [x] `bun run build` clean (tsc --noEmit)
- [x] `bun test tests/http/menu/` — 4 pass (grouping, ordering/dedupe, unmapped-skip, self-tag)
- [x] `bun test tests/http/` — 107 pass, 0 fail, no regression
- [ ] Manual: hit `/api/menu` on running server, confirm payload matches studio's parser output

🤖 ตอบโดย arra-oracle-v3 (red) จาก Nat → arra-oracle-v3

🤖 Generated with [Claude Code](https://claude.com/claude-code)