### PR TITLE
fix(menu): short nav labels (Search, Feed, Forum vs 'Hybrid search over oracle docs')

### DIFF
--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -71,8 +71,8 @@ export function buildMenuItems(sources: HasRoutes[]): MenuItem[] {
       const parsed = orderTag ? parseInt(orderTag.slice('order:'.length), 10) : NaN;
       const order = Number.isFinite(parsed) ? parsed : 999;
 
-      const summary = typeof detail.summary === 'string' ? detail.summary : '';
-      const label = summary || studio.replace('/', '') || 'Home';
+      const slug = studio.replace(/^\//, '') || 'home';
+      const label = slug.charAt(0).toUpperCase() + slug.slice(1);
 
       items.push({ path: studio, label, group, order, source: 'api' });
     }


### PR DESCRIPTION
Previous /api/menu used OpenAPI summaries ('Hybrid search over oracle docs') which are too verbose for nav. Now derives Title-cased label from studio path slug ('/search' → 'Search'). Summary stays in /swagger as API doc.