### PR TITLE
docs: hook-menu package extracted (closes #906)

### DIFF
--- a/docs/HOOK-MENU-PACKAGE.md
+++ b/docs/HOOK-MENU-PACKAGE.md
@@ -1,0 +1,45 @@
+# hook-menu package
+
+> **Status**: Extracted, not yet consumed. This repo still uses the in-tree copy under `src/routes/menu/` and `src/menu/`.
+
+The reusable parts of the Oracle navigation system — TypeBox schemas, `buildMenuItems`, studio-tag helpers, and the Elysia plugin — have been lifted into a standalone repo:
+
+**→ https://github.com/Soul-Brews-Studio/hook-menu**
+
+## What moved
+
+| In-tree source | hook-menu module |
+|---|---|
+| `src/routes/menu/model.ts` | `hook-menu/model` — `MenuItem`, `MenuItemSchema`, `MenuResponseSchema` |
+| `src/routes/menu/menu.ts` (`buildMenuItems` + `API_TO_STUDIO`) | `hook-menu/build` — `buildMenuItems`, `defineMenu`, `API_TO_STUDIO` |
+| `src/routes/menu/studio-tag.ts`, `studio-href.ts` | `hook-menu/studio` — `parseStudioTag`, `studioHref` |
+| `src/menu/frontend.ts` (hardcoded items) | `hook-menu/frontend` — `defineFrontendMenu` (parametrized — takes items as input) |
+| `src/routes/menu/menu.ts` (`createMenuEndpoint`) | `hook-menu/elysia` — `mountMenu` |
+
+## What did not move
+
+- The hardcoded frontend items list (`/canvas`, `/planets`, `/map`, …) stays arra-specific. The package exposes a parametrized `defineFrontendMenu` that accepts an items array.
+- React hooks / components — explicitly out of scope for v0.1 (backend only).
+
+## Install pattern
+
+No npm publish. Consume directly from GitHub via Bun:
+
+```bash
+bunx github:Soul-Brews-Studio/hook-menu
+```
+
+Or as a dep:
+
+```json
+{ "dependencies": { "hook-menu": "github:Soul-Brews-Studio/hook-menu" } }
+```
+
+## Follow-up
+
+Swapping arra-oracle-v3's in-tree `src/routes/menu/*` + `src/menu/*` for `hook-menu` imports is deliberately **not** part of #906. Track that as a separate task — it's a pure migration once the package stabilizes.
+
+## Origin
+
+- Extracted from commits landing Oracle menu work prior to 2026-04-19.
+- Closes #906.


### PR DESCRIPTION
## Summary
- Extracts the reusable Drupal-style hook_menu helpers into a new standalone repo: **https://github.com/Soul-Brews-Studio/hook-menu**
- Adds `docs/HOOK-MENU-PACKAGE.md` explaining what moved, what stayed, and how to consume the package via `bunx github:Soul-Brews-Studio/hook-menu`
- Docs-only PR — the in-tree `src/routes/menu/*` and `src/menu/*` are untouched

## Scope
Backend-only v0.1: schemas, `buildMenuItems`, studio helpers, parametrized frontend factory, Elysia plugin. React hooks/components are a follow-up.

The hardcoded frontend items list is kept arra-specific — the package exposes `defineFrontendMenu(items)` that takes the array as input rather than baking it in.

## Follow-up (NOT in this PR)
Swapping arra-oracle-v3 imports to consume `hook-menu` is a deliberate separate task once the package stabilizes.

Closes #906.

## Test plan
- [ ] `docs/HOOK-MENU-PACKAGE.md` renders correctly on GitHub
- [ ] Linked repo https://github.com/Soul-Brews-Studio/hook-menu is public and cloneable
- [ ] `bunx github:Soul-Brews-Studio/hook-menu` resolves (peer deps documented)

🤖 ตอบโดย arra-oracle-v3 จาก [ณัฐ วีระวรรณ์] → arra-oracle-v3-oracle