### PR TITLE
feat(cli): arra-cli menu list|add|remove

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,6 +11,9 @@ import { pluginsInfo } from "./commands/plugins-info.ts";
 import { sessionList } from "./commands/session-list.ts";
 import { sessionShow } from "./commands/session-show.ts";
 import { sessionContext } from "./commands/session-context.ts";
+import { menuList } from "./commands/menu-list.ts";
+import { menuAdd } from "./commands/menu-add.ts";
+import { menuRemove } from "./commands/menu-remove.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -21,6 +24,7 @@ function printHelp(commands: Array<{ command: string; help?: string }>) {
   console.log("Commands:");
   console.log(`  ${"plugin".padEnd(16)}manage plugins (install)`);
   console.log(`  ${"session".padEnd(16)}inspect sessions (list, show, context)`);
+  console.log(`  ${"menu".padEnd(16)}inspect and customize studio menu (list, add, remove)`);
   for (const { command, help } of commands) {
     console.log(`  ${command.padEnd(16)}${help ?? ""}`);
   }
@@ -89,6 +93,35 @@ async function main() {
     }
     console.error(`\x1b[31m✗\x1b[0m unknown session subcommand: ${args[1]}`);
     console.error("  try: arra-cli session list|show|context");
+    process.exit(1);
+  }
+
+  if (cmd === "menu") {
+    const sub = args[1]?.toLowerCase();
+    const rest = args.slice(2);
+    if (sub === "list" || sub === "ls") {
+      process.exit(await menuList(rest));
+    }
+    if (sub === "add") {
+      process.exit(await menuAdd(rest));
+    }
+    if (sub === "remove" || sub === "rm") {
+      process.exit(await menuRemove(rest));
+    }
+    if (!sub || sub === "--help" || sub === "-h") {
+      console.log("arra-cli menu <subcommand>\n");
+      console.log("Subcommands:");
+      console.log("  list [--custom]                         list menu items (JSON array)");
+      console.log("  add --path /p --label L [--group g] [--order N] [--icon i]");
+      console.log("                                          add or replace a custom menu item");
+      console.log("  remove <path>                           remove a custom menu item");
+      console.log("\nOutput defaults to JSON; pass --yml for YAML.");
+      console.log("\nEnv:");
+      console.log("  ORACLE_API          API base URL (default http://localhost:47778)");
+      return;
+    }
+    console.error(`\x1b[31m✗\x1b[0m unknown menu subcommand: ${args[1]}`);
+    console.error("  try: arra-cli menu list|add|remove");
     process.exit(1);
   }
 

--- a/cli/src/commands/menu-add.ts
+++ b/cli/src/commands/menu-add.ts
@@ -1,0 +1,72 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
+
+function flagValue(args: string[], name: string): string | undefined {
+  const eq = args.find((a) => a.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const idx = args.indexOf(name);
+  if (idx >= 0 && idx + 1 < args.length) {
+    const next = args[idx + 1];
+    if (!next.startsWith("-")) return next;
+  }
+  return undefined;
+}
+
+const VALID_GROUPS = new Set(["main", "tools", "hidden", "admin"]);
+
+export async function menuAdd(args: string[]): Promise<number> {
+  const path = flagValue(args, "--path");
+  const label = flagValue(args, "--label");
+  const group = flagValue(args, "--group");
+  const orderRaw = flagValue(args, "--order");
+  const icon = flagValue(args, "--icon");
+
+  if (!path || !label) {
+    console.error(
+      "usage: arra-cli menu add --path /foo --label Foo [--group tools] [--order 90] [--icon star]",
+    );
+    return 1;
+  }
+
+  if (group && !VALID_GROUPS.has(group)) {
+    console.error(`invalid --group '${group}' (expected: main|tools|hidden|admin)`);
+    return 1;
+  }
+
+  let order: number | undefined;
+  if (orderRaw !== undefined) {
+    const parsed = Number(orderRaw);
+    if (!Number.isFinite(parsed)) {
+      console.error(`invalid --order '${orderRaw}' (expected number)`);
+      return 1;
+    }
+    order = parsed;
+  }
+
+  const body: Record<string, unknown> = { path, label };
+  if (group) body.group = group;
+  if (order !== undefined) body.order = order;
+  if (icon) body.icon = icon;
+
+  let res: Response;
+  try {
+    res = await sessionFetch("/api/menu/custom", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`\x1b[31m✗\x1b[0m POST /api/menu/custom failed: HTTP ${res.status}`);
+    if (text) console.error(`  ${text}`);
+    return 1;
+  }
+
+  const data = (await res.json()) as { added?: boolean; replaced?: boolean; item?: unknown };
+  emit({ api: sessionApiBase(), added: !!data.added, replaced: !!data.replaced, item: data.item }, args);
+  return 0;
+}

--- a/cli/src/commands/menu-list.ts
+++ b/cli/src/commands/menu-list.ts
@@ -1,0 +1,24 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
+
+export async function menuList(args: string[]): Promise<number> {
+  const customOnly = args.includes("--custom");
+  const endpoint = customOnly ? "/api/menu/custom" : "/api/menu";
+
+  let res: Response;
+  try {
+    res = await sessionFetch(endpoint);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m GET ${endpoint} failed: HTTP ${res.status}`);
+    return 1;
+  }
+
+  const data = (await res.json()) as { items?: unknown[] };
+  const items = Array.isArray(data.items) ? data.items : [];
+  emit({ api: sessionApiBase(), endpoint, items }, args);
+  return 0;
+}

--- a/cli/src/commands/menu-remove.ts
+++ b/cli/src/commands/menu-remove.ts
@@ -1,0 +1,32 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
+
+export async function menuRemove(args: string[]): Promise<number> {
+  const target = args.find((a) => !a.startsWith("-"));
+  if (!target) {
+    console.error("usage: arra-cli menu remove <path>");
+    return 1;
+  }
+  const normalized = target.startsWith("/") ? target : `/${target}`;
+  const encoded = encodeURIComponent(normalized.replace(/^\//, ""));
+
+  let res: Response;
+  try {
+    res = await sessionFetch(`/api/menu/custom/${encoded}`, { method: "DELETE" });
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return 1;
+  }
+  if (!res.ok && res.status !== 404) {
+    console.error(`\x1b[31m✗\x1b[0m DELETE /api/menu/custom failed: HTTP ${res.status}`);
+    return 1;
+  }
+
+  const data = (await res.json()) as { removed?: boolean; path?: string };
+  if (!data.removed) {
+    emit({ api: sessionApiBase(), removed: false, path: data.path ?? normalized }, args);
+    return 1;
+  }
+  emit({ api: sessionApiBase(), removed: true, path: data.path ?? normalized }, args);
+  return 0;
+}

--- a/src/menu/custom-store.ts
+++ b/src/menu/custom-store.ts
@@ -1,0 +1,103 @@
+/**
+ * Custom menu items — user-added entries stored at ORACLE_DATA_DIR/custom-menu.json.
+ *
+ * Not tied to any sqlite schema so users can hand-edit / back up / reset the file
+ * independently. Merges into the aggregated /api/menu with source:'page' + added:true.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import type { MenuItem } from '../routes/menu/model.ts';
+import { ORACLE_DATA_DIR } from '../config.ts';
+
+export const CUSTOM_MENU_FILE = path.join(ORACLE_DATA_DIR, 'custom-menu.json');
+
+export interface CustomMenuInput {
+  path: string;
+  label: string;
+  group?: MenuItem['group'];
+  order?: number;
+  icon?: string;
+}
+
+type RawFile = { items?: CustomMenuInput[] };
+
+function readRaw(file = CUSTOM_MENU_FILE): CustomMenuInput[] {
+  if (!fs.existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8')) as RawFile | CustomMenuInput[];
+    const arr = Array.isArray(parsed) ? parsed : parsed.items ?? [];
+    return arr.filter(
+      (i): i is CustomMenuInput =>
+        !!i && typeof i.path === 'string' && typeof i.label === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeRaw(items: CustomMenuInput[], file = CUSTOM_MENU_FILE): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify({ items }, null, 2) + '\n');
+}
+
+function normalizePath(p: string): string {
+  const trimmed = p.trim();
+  if (!trimmed) return trimmed;
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
+export function listCustomMenuItems(file = CUSTOM_MENU_FILE): MenuItem[] {
+  return readRaw(file).map((i) => ({
+    path: normalizePath(i.path),
+    label: i.label,
+    group: i.group ?? 'tools',
+    order: typeof i.order === 'number' ? i.order : 90,
+    icon: i.icon,
+    source: 'page' as const,
+  }));
+}
+
+export function addCustomMenuItem(
+  input: CustomMenuInput,
+  file = CUSTOM_MENU_FILE,
+): { added: boolean; replaced: boolean; item: MenuItem } {
+  const cleaned: CustomMenuInput = {
+    path: normalizePath(input.path),
+    label: input.label,
+    group: input.group ?? 'tools',
+    order: typeof input.order === 'number' ? input.order : 90,
+    icon: input.icon,
+  };
+  const existing = readRaw(file);
+  const idx = existing.findIndex((i) => normalizePath(i.path) === cleaned.path);
+  let replaced = false;
+  if (idx >= 0) {
+    existing[idx] = cleaned;
+    replaced = true;
+  } else {
+    existing.push(cleaned);
+  }
+  writeRaw(existing, file);
+  const item: MenuItem = {
+    path: cleaned.path,
+    label: cleaned.label,
+    group: cleaned.group!,
+    order: cleaned.order!,
+    icon: cleaned.icon,
+    source: 'page',
+  };
+  return { added: !replaced, replaced, item };
+}
+
+export function removeCustomMenuItem(
+  rawPath: string,
+  file = CUSTOM_MENU_FILE,
+): { removed: boolean; path: string } {
+  const target = normalizePath(rawPath);
+  const existing = readRaw(file);
+  const next = existing.filter((i) => normalizePath(i.path) !== target);
+  const removed = next.length !== existing.length;
+  if (removed) writeRaw(next, file);
+  return { removed, path: target };
+}

--- a/src/routes/menu/custom.ts
+++ b/src/routes/menu/custom.ts
@@ -1,0 +1,76 @@
+/**
+ * /api/menu/custom — user-added menu items.
+ *
+ *   GET    /api/menu/custom           list just the user-added items
+ *   POST   /api/menu/custom           add (or replace by path) a custom item
+ *   DELETE /api/menu/custom/:path     remove a custom item (path URL-encoded)
+ *
+ * Custom items also merge into GET /api/menu with source:'page' + added:true.
+ */
+
+import { Elysia, t } from 'elysia';
+import { MenuItemSchema } from './model.ts';
+import {
+  addCustomMenuItem,
+  listCustomMenuItems,
+  removeCustomMenuItem,
+} from '../../menu/custom-store.ts';
+
+const GroupSchema = t.Union([
+  t.Literal('main'),
+  t.Literal('tools'),
+  t.Literal('hidden'),
+  t.Literal('admin'),
+]);
+
+export function createCustomMenuRoutes() {
+  return new Elysia()
+    .get(
+      '/menu/custom',
+      () => ({ items: listCustomMenuItems().map((i) => ({ ...i, added: true })) }),
+      {
+        detail: {
+          tags: ['menu', 'nav:hidden'],
+          summary: 'List user-added custom menu items',
+        },
+        response: t.Object({ items: t.Array(MenuItemSchema) }),
+      },
+    )
+    .post(
+      '/menu/custom',
+      ({ body, set }) => {
+        const result = addCustomMenuItem(body);
+        set.status = result.replaced ? 200 : 201;
+        return { ...result, item: { ...result.item, added: true } };
+      },
+      {
+        body: t.Object({
+          path: t.String({ minLength: 1 }),
+          label: t.String({ minLength: 1 }),
+          group: t.Optional(GroupSchema),
+          order: t.Optional(t.Number()),
+          icon: t.Optional(t.String()),
+        }),
+        detail: {
+          tags: ['menu', 'nav:hidden'],
+          summary: 'Add or replace a user-added custom menu item',
+        },
+      },
+    )
+    .delete(
+      '/menu/custom/*',
+      ({ params, set }) => {
+        const raw = (params as { '*': string })['*'] ?? '';
+        const decoded = decodeURIComponent(raw);
+        const result = removeCustomMenuItem(decoded);
+        if (!result.removed) set.status = 404;
+        return result;
+      },
+      {
+        detail: {
+          tags: ['menu', 'nav:hidden'],
+          summary: 'Remove a user-added custom menu item by path',
+        },
+      },
+    );
+}

--- a/src/routes/menu/index.ts
+++ b/src/routes/menu/index.ts
@@ -7,11 +7,14 @@
 
 import { Elysia } from 'elysia';
 import { createMenuEndpoint } from './menu.ts';
+import { createCustomMenuRoutes } from './custom.ts';
 
 type HasRoutes = { routes: Array<{ path: string; hooks?: { detail?: unknown } }> };
 
 export function createMenuRoutes(sources: HasRoutes[]) {
-  return new Elysia({ prefix: '/api' }).use(createMenuEndpoint(sources));
+  return new Elysia({ prefix: '/api' })
+    .use(createMenuEndpoint(sources))
+    .use(createCustomMenuRoutes());
 }
 
 export { buildMenuItems, API_TO_STUDIO } from './menu.ts';

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -9,6 +9,7 @@
 import { Elysia } from 'elysia';
 import { MenuItemSchema, MenuResponseSchema, type MenuItem } from './model.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
+import { listCustomMenuItems } from '../../menu/custom-store.ts';
 
 export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
   ['/api/supersede', '/superseded'],
@@ -38,7 +39,10 @@ type HasRoutes = { routes: RouteLike[] };
 
 const GROUP_RANK: Record<MenuItem['group'], number> = { main: 0, tools: 1, admin: 2, hidden: 3 };
 
-export function buildMenuItems(sources: HasRoutes[]): MenuItem[] {
+export function buildMenuItems(
+  sources: HasRoutes[],
+  customItems: MenuItem[] = [],
+): MenuItem[] {
   const items: MenuItem[] = [];
   const seen = new Set<string>();
 
@@ -86,6 +90,13 @@ export function buildMenuItems(sources: HasRoutes[]): MenuItem[] {
     items.push(item);
   }
 
+  for (const item of customItems) {
+    const key = `${item.group}:${item.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    items.push({ ...item, added: true });
+  }
+
   items.sort((a, b) => GROUP_RANK[a.group] - GROUP_RANK[b.group] || a.order - b.order);
   return items;
 }
@@ -93,7 +104,7 @@ export function buildMenuItems(sources: HasRoutes[]): MenuItem[] {
 export function createMenuEndpoint(sources: HasRoutes[]) {
   return new Elysia().get(
     '/menu',
-    () => ({ items: buildMenuItems(sources) }),
+    () => ({ items: buildMenuItems(sources, listCustomMenuItems()) }),
     {
       detail: {
         tags: ['menu', 'nav:hidden'],

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -23,6 +23,7 @@ export const MenuItemSchema = t.Object({
     t.Literal('page'),
     t.Literal('plugin'),
   ]),
+  added: t.Optional(t.Boolean()),
 });
 
 export type MenuItem = Static<typeof MenuItemSchema>;

--- a/tests/cli/menu/add.test.ts
+++ b/tests/cli/menu/add.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { runCli, tryParseJson } from "../_run.ts";
+import { ensureServer, stopServer } from "../_server.ts";
+
+const TEST_PATH = `/__arra_cli_menu_add_test_${Date.now()}__`;
+
+async function cleanup(path: string): Promise<void> {
+  await runCli(["menu", "remove", path]);
+}
+
+describe("arra-cli menu add", () => {
+  beforeAll(async () => { await ensureServer(); }, 30_000);
+  afterAll(async () => {
+    await cleanup(TEST_PATH);
+    stopServer();
+  });
+
+  test("missing flags → non-zero with usage", async () => {
+    const result = await runCli(["menu", "add"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/usage:.*menu add/);
+  }, 15_000);
+
+  test("invalid --group → rejected", async () => {
+    const result = await runCli(["menu", "add", "--path", "/x", "--label", "X", "--group", "bogus"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/invalid --group/);
+  }, 15_000);
+
+  test("adds a custom item and returns JSON", async () => {
+    const result = await runCli([
+      "menu", "add",
+      "--path", TEST_PATH,
+      "--label", "CLI Test",
+      "--group", "tools",
+      "--order", "91",
+    ]);
+    if (result.code === 0) {
+      const data = tryParseJson(result.stdout) as
+        | { added: boolean; replaced: boolean; item: { path: string; label: string; added: boolean } }
+        | null;
+      expect(data).not.toBeNull();
+      expect(data!.item.path).toBe(TEST_PATH);
+      expect(data!.item.label).toBe("CLI Test");
+      expect(data!.item.added).toBe(true);
+      expect(data!.added || data!.replaced).toBe(true);
+    } else {
+      expect(result.stderr).toMatch(/HTTP 404|failed/);
+    }
+  }, 15_000);
+
+  test("second add with same path → replaces (replaced:true)", async () => {
+    await runCli([
+      "menu", "add", "--path", TEST_PATH, "--label", "First",
+    ]);
+    const result = await runCli([
+      "menu", "add", "--path", TEST_PATH, "--label", "Second",
+    ]);
+    if (result.code === 0) {
+      const data = tryParseJson(result.stdout) as { replaced: boolean; item: { label: string } } | null;
+      expect(data).not.toBeNull();
+      expect(data!.replaced).toBe(true);
+      expect(data!.item.label).toBe("Second");
+    }
+  }, 15_000);
+});

--- a/tests/cli/menu/list.test.ts
+++ b/tests/cli/menu/list.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { runCli, tryParseJson } from "../_run.ts";
+import { ensureServer, stopServer } from "../_server.ts";
+
+describe("arra-cli menu list", () => {
+  beforeAll(async () => { await ensureServer(); }, 30_000);
+  afterAll(() => stopServer());
+
+  test("default JSON output returns items array", async () => {
+    const result = await runCli(["menu", "list"]);
+    if (result.code === 0) {
+      const data = tryParseJson(result.stdout) as
+        | { api: string; endpoint: string; items: unknown[] }
+        | null;
+      expect(data).not.toBeNull();
+      expect(typeof data!.api).toBe("string");
+      expect(data!.endpoint).toBe("/api/menu");
+      expect(Array.isArray(data!.items)).toBe(true);
+    } else {
+      expect(result.stderr).toMatch(/HTTP 404|failed/);
+    }
+  }, 15_000);
+
+  test("--custom → hits /api/menu/custom", async () => {
+    const result = await runCli(["menu", "list", "--custom"]);
+    if (result.code === 0) {
+      const data = tryParseJson(result.stdout) as { endpoint: string; items: unknown[] } | null;
+      expect(data).not.toBeNull();
+      expect(data!.endpoint).toBe("/api/menu/custom");
+      expect(Array.isArray(data!.items)).toBe(true);
+    }
+  }, 15_000);
+
+  test("--yml flag produces non-JSON output", async () => {
+    const result = await runCli(["menu", "list", "--yml"]);
+    if (result.code === 0) {
+      expect(tryParseJson(result.stdout)).toBeNull();
+      expect(result.stdout).toMatch(/items:|api:/);
+    }
+  }, 15_000);
+});

--- a/tests/cli/menu/remove.test.ts
+++ b/tests/cli/menu/remove.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { runCli, tryParseJson } from "../_run.ts";
+import { ensureServer, stopServer } from "../_server.ts";
+
+const TEST_PATH = `/__arra_cli_menu_rm_test_${Date.now()}__`;
+
+describe("arra-cli menu remove", () => {
+  beforeAll(async () => { await ensureServer(); }, 30_000);
+  afterAll(() => stopServer());
+
+  test("missing path → non-zero with usage", async () => {
+    const result = await runCli(["menu", "remove"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/usage:.*menu remove/);
+  }, 15_000);
+
+  test("remove nonexistent → exit 1 with removed:false", async () => {
+    const result = await runCli([
+      "menu", "remove", `/__nonexistent_${Date.now()}__`,
+    ]);
+    // Either endpoint missing (HTTP 404 bubble) or removed:false returned.
+    if (result.stdout) {
+      const data = tryParseJson(result.stdout) as { removed: boolean } | null;
+      if (data) expect(data.removed).toBe(false);
+    }
+    expect(result.code).not.toBe(0);
+  }, 15_000);
+
+  test("add then remove → removed:true", async () => {
+    const addResult = await runCli([
+      "menu", "add", "--path", TEST_PATH, "--label", "RM Test",
+    ]);
+    if (addResult.code !== 0) return; // endpoint missing on older server
+    const result = await runCli(["menu", "remove", TEST_PATH]);
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as { removed: boolean; path: string } | null;
+    expect(data).not.toBeNull();
+    expect(data!.removed).toBe(true);
+    expect(data!.path).toBe(TEST_PATH);
+  }, 15_000);
+});


### PR DESCRIPTION
## Summary
- New \`arra-cli menu\` subcommands: \`list\`, \`add\`, \`remove\`
- Backend \`/api/menu/custom\` endpoints (GET/POST/DELETE) persist user-added items to \`ORACLE_DATA_DIR/custom-menu.json\`
- Custom items merge into \`/api/menu\` with \`source:'page'\` + \`added:true\`

## Test plan
- [x] \`bun run build\` clean
- [x] \`bun test tests/cli\` — 21/21 pass (10 new menu tests)
- [x] End-to-end probe: add → list --custom → remove against spawned server
- [x] Mirrors existing session/plugin command patterns; default JSON, \`--yml\` for YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)