### PR TITLE
feat(menu): gist URL source — persistent settings + CLI (#929 Part A)

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -14,6 +14,12 @@ import { sessionContext } from "./commands/session-context.ts";
 import { menuList } from "./commands/menu-list.ts";
 import { menuAdd } from "./commands/menu-add.ts";
 import { menuRemove } from "./commands/menu-remove.ts";
+import {
+  menuGistStatus,
+  menuGistUrl,
+  menuGistClear,
+  menuGistReload,
+} from "./commands/menu-gist.ts";
 
 const pkg = await Bun.file(join(import.meta.dir, "../package.json")).json();
 const VERSION: string = pkg.version;
@@ -108,6 +114,18 @@ async function main() {
     if (sub === "remove" || sub === "rm") {
       process.exit(await menuRemove(rest));
     }
+    if (sub === "gist-status") {
+      process.exit(await menuGistStatus(rest));
+    }
+    if (sub === "gist-url") {
+      process.exit(await menuGistUrl(rest));
+    }
+    if (sub === "gist-clear") {
+      process.exit(await menuGistClear(rest));
+    }
+    if (sub === "gist-reload") {
+      process.exit(await menuGistReload(rest));
+    }
     if (!sub || sub === "--help" || sub === "-h") {
       console.log("arra-cli menu <subcommand>\n");
       console.log("Subcommands:");
@@ -115,13 +133,17 @@ async function main() {
       console.log("  add --path /p --label L [--group g] [--order N] [--icon i]");
       console.log("                                          add or replace a custom menu item");
       console.log("  remove <path>                           remove a custom menu item");
+      console.log("  gist-status                             show current gist source");
+      console.log("  gist-url <url>                          set gist URL for menu source");
+      console.log("  gist-clear                              clear gist URL");
+      console.log("  gist-reload                             force refetch of gist menu");
       console.log("\nOutput defaults to JSON; pass --yml for YAML.");
       console.log("\nEnv:");
       console.log("  ORACLE_API          API base URL (default http://localhost:47778)");
       return;
     }
     console.error(`\x1b[31m✗\x1b[0m unknown menu subcommand: ${args[1]}`);
-    console.error("  try: arra-cli menu list|add|remove");
+    console.error("  try: arra-cli menu list|add|remove|gist-status|gist-url|gist-clear|gist-reload");
     process.exit(1);
   }
 

--- a/cli/src/commands/menu-gist.ts
+++ b/cli/src/commands/menu-gist.ts
@@ -1,0 +1,71 @@
+import { sessionApiBase, sessionFetch } from "./session-api.ts";
+import { emit } from "./_output.ts";
+
+async function fetchJson(
+  path: string,
+  opts?: RequestInit,
+): Promise<{ code: number; body: unknown; status: number } | { code: 1 }> {
+  let res: Response;
+  try {
+    res = await sessionFetch(path, opts);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    return { code: 1 };
+  }
+  let body: unknown = null;
+  const text = await res.text();
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  if (!res.ok) {
+    console.error(`\x1b[31m✗\x1b[0m ${opts?.method ?? "GET"} ${path} failed: HTTP ${res.status}`);
+    if (body && typeof body === "object" && "error" in (body as Record<string, unknown>)) {
+      console.error(`  ${(body as { error: string }).error}`);
+    } else if (typeof body === "string" && body) {
+      console.error(`  ${body}`);
+    }
+    return { code: 1, body, status: res.status };
+  }
+  return { code: 0, body, status: res.status };
+}
+
+export async function menuGistStatus(args: string[]): Promise<number> {
+  const result = await fetchJson("/api/menu/source");
+  if (result.code !== 0) return 1;
+  emit({ api: sessionApiBase(), source: result.body }, args);
+  return 0;
+}
+
+export async function menuGistUrl(args: string[]): Promise<number> {
+  const url = args.find((a) => !a.startsWith("-"));
+  if (!url) {
+    console.error("usage: arra-cli menu gist-url <url>");
+    return 1;
+  }
+  const result = await fetchJson("/api/menu/source", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (result.code !== 0) return 1;
+  emit({ api: sessionApiBase(), source: result.body }, args);
+  return 0;
+}
+
+export async function menuGistClear(args: string[]): Promise<number> {
+  const result = await fetchJson("/api/menu/source", { method: "DELETE" });
+  if (result.code !== 0) return 1;
+  emit({ api: sessionApiBase(), cleared: true, source: result.body }, args);
+  return 0;
+}
+
+export async function menuGistReload(args: string[]): Promise<number> {
+  const result = await fetchJson("/api/menu/reload", { method: "POST" });
+  if (result.code !== 0) return 1;
+  emit({ api: sessionApiBase(), reloaded: true, source: result.body }, args);
+  return 0;
+}

--- a/src/menu/config.ts
+++ b/src/menu/config.ts
@@ -1,5 +1,5 @@
 import type { MenuItem } from '../routes/menu/model.ts';
-import { getSetting } from '../db/index.ts';
+import { getSetting, setSetting } from '../db/index.ts';
 import { fetchGistMenu, invalidateGistCache } from './gist.ts';
 
 export type MenuConfig = {
@@ -23,6 +23,18 @@ let sourceState: MenuSource = {
 
 export function getMenuSource(): MenuSource {
   return { ...sourceState };
+}
+
+export const MENU_GIST_SETTING_KEY = 'menu_gist_url';
+
+function resolveGistUrl(): string | null {
+  const fromDb = getSetting(MENU_GIST_SETTING_KEY);
+  if (fromDb && fromDb.trim()) return fromDb.trim();
+  const fromEnvNew = process.env.ORACLE_MENU_GIST_URL;
+  if (fromEnvNew && fromEnvNew.trim()) return fromEnvNew.trim();
+  const fromEnv = process.env.ORACLE_MENU_GIST;
+  if (fromEnv && fromEnv.trim()) return fromEnv.trim();
+  return null;
 }
 
 function readEnvDisable(): string[] {
@@ -50,7 +62,7 @@ export async function getMenuConfig(): Promise<MenuConfig> {
   for (const p of readEnvDisable()) disable.add(p);
   for (const p of readDbDisable()) disable.add(p);
 
-  const gistUrl = process.env.ORACLE_MENU_GIST;
+  const gistUrl = resolveGistUrl();
   if (!gistUrl) {
     sourceState = { url: null, hash: null, loaded_at: null, status: 'none' };
     return { items, disable };
@@ -83,9 +95,16 @@ export async function getMenuConfig(): Promise<MenuConfig> {
 }
 
 export async function reloadMenuConfig(): Promise<MenuConfig> {
-  const gistUrl = process.env.ORACLE_MENU_GIST;
+  const gistUrl = resolveGistUrl();
   if (gistUrl) invalidateGistCache(gistUrl);
+  else invalidateGistCache();
   return getMenuConfig();
+}
+
+export function setMenuGistUrl(url: string | null): void {
+  setSetting(MENU_GIST_SETTING_KEY, url);
+  invalidateGistCache();
+  sourceState = { url: null, hash: null, loaded_at: null, status: 'none' };
 }
 
 export function _resetMenuSource(): void {

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -13,7 +13,13 @@ import { Elysia, t } from 'elysia';
 import { asc } from 'drizzle-orm';
 import { MenuItemSchema, MenuResponseSchema, type MenuItem, type MenuMeta } from './model.ts';
 import { getFrontendMenuItems } from '../../menu/index.ts';
-import { getMenuConfig, getMenuSource, reloadMenuConfig } from '../../menu/config.ts';
+import {
+  getMenuConfig,
+  getMenuSource,
+  reloadMenuConfig,
+  setMenuGistUrl,
+} from '../../menu/config.ts';
+import { parseGistUrl } from '../../menu/gist.ts';
 import { listCustomMenuItems } from '../../menu/custom-store.ts';
 import { db, menuItems } from '../../db/index.ts';
 
@@ -219,6 +225,49 @@ export function createMenuEndpoint() {
           tags: ['menu'],
           menu: { group: 'hidden' },
           summary: 'Force refetch of gist menu source, bypassing cache',
+        },
+      },
+    )
+    .post(
+      '/menu/source',
+      async ({ body, set }) => {
+        const raw = body.url.trim();
+        if (!raw) {
+          set.status = 400;
+          return { error: 'url required' };
+        }
+        if (!parseGistUrl(raw)) {
+          set.status = 400;
+          return {
+            error: 'invalid gist URL (expected https://gist.github.com/<user>/<id>[/<hash>])',
+          };
+        }
+        setMenuGistUrl(raw);
+        await reloadMenuConfig();
+        return getMenuSource();
+      },
+      {
+        body: t.Object({ url: t.String() }),
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Set gist URL for menu source (persists via settings)',
+        },
+      },
+    )
+    .delete(
+      '/menu/source',
+      async () => {
+        setMenuGistUrl(null);
+        await reloadMenuConfig();
+        return getMenuSource();
+      },
+      {
+        response: MenuSourceSchema,
+        detail: {
+          tags: ['menu'],
+          menu: { group: 'hidden' },
+          summary: 'Clear gist URL from menu source',
         },
       },
     );

--- a/tests/cli/menu/gist.test.ts
+++ b/tests/cli/menu/gist.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { runCli, tryParseJson } from "../_run.ts";
+import { ensureServer, stopServer, BASE_URL } from "../_server.ts";
+
+async function clearGist(): Promise<void> {
+  await fetch(`${BASE_URL}/api/menu/source`, { method: "DELETE" });
+}
+
+describe("arra-cli menu gist-*", () => {
+  beforeAll(async () => {
+    await ensureServer();
+  }, 30_000);
+  afterAll(async () => {
+    await clearGist();
+    stopServer();
+  });
+  beforeEach(async () => {
+    await clearGist();
+  });
+
+  test("gist-status returns source JSON (status:none initially)", async () => {
+    const result = await runCli(["menu", "gist-status"]);
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as { source: { status: string; url: string | null } } | null;
+    expect(data).not.toBeNull();
+    expect(data!.source.status).toBe("none");
+    expect(data!.source.url).toBeNull();
+  }, 15_000);
+
+  test("gist-url without arg → usage error", async () => {
+    const result = await runCli(["menu", "gist-url"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/usage:.*gist-url/);
+  }, 15_000);
+
+  test("gist-url with invalid URL → HTTP 400", async () => {
+    const result = await runCli(["menu", "gist-url", "https://example.com/not-a-gist"]);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toMatch(/HTTP 400|invalid gist URL/);
+  }, 15_000);
+
+  test("gist-url → gist-status → gist-clear round-trip", async () => {
+    const url = "https://gist.github.com/natw/c11eabcd01";
+    const setRes = await runCli(["menu", "gist-url", url]);
+    expect(setRes.code).toBe(0);
+    const setData = tryParseJson(setRes.stdout) as { source: { url: string | null } } | null;
+    expect(setData?.source.url).toBe(url);
+
+    const statusRes = await runCli(["menu", "gist-status"]);
+    expect(statusRes.code).toBe(0);
+    const statusData = tryParseJson(statusRes.stdout) as { source: { url: string | null } } | null;
+    expect(statusData?.source.url).toBe(url);
+
+    const clearRes = await runCli(["menu", "gist-clear"]);
+    expect(clearRes.code).toBe(0);
+    const clearData = tryParseJson(clearRes.stdout) as
+      | { cleared: boolean; source: { status: string; url: string | null } }
+      | null;
+    expect(clearData?.cleared).toBe(true);
+    expect(clearData?.source.status).toBe("none");
+
+    const statusAfter = await runCli(["menu", "gist-status"]);
+    const statusAfterData = tryParseJson(statusAfter.stdout) as { source: { url: string | null } } | null;
+    expect(statusAfterData?.source.url).toBeNull();
+  }, 30_000);
+
+  test("gist-reload returns source JSON", async () => {
+    const result = await runCli(["menu", "gist-reload"]);
+    expect(result.code).toBe(0);
+    const data = tryParseJson(result.stdout) as
+      | { reloaded: boolean; source: { status: string } }
+      | null;
+    expect(data?.reloaded).toBe(true);
+    expect(data?.source.status).toBe("none");
+  }, 15_000);
+});

--- a/tests/http/menu/gist-source.test.ts
+++ b/tests/http/menu/gist-source.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests for POST /api/menu/source + DELETE /api/menu/source.
+ *
+ * Covers:
+ *  - POST persists gist URL via settings, returns source
+ *  - POST rejects invalid URL (400)
+ *  - POST rejects empty URL (400)
+ *  - DELETE clears settings, returns status:none
+ *  - Boot reads settings first, env var second
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createMenuEndpoint } from '../../../src/routes/menu/menu.ts';
+import { setSetting, getSetting } from '../../../src/db/index.ts';
+import {
+  MENU_GIST_SETTING_KEY,
+  _resetMenuSource,
+  getMenuConfig,
+} from '../../../src/menu/config.ts';
+import { _clearGistCache, _setRetryDelays } from '../../../src/menu/gist.ts';
+
+const ORIG_FETCH = globalThis.fetch;
+const ORIG_ENV_GIST = process.env.ORACLE_MENU_GIST;
+const ORIG_ENV_GIST_URL = process.env.ORACLE_MENU_GIST_URL;
+
+function restoreFetch() {
+  globalThis.fetch = ORIG_FETCH;
+}
+
+function resetAll() {
+  _clearGistCache();
+  _resetMenuSource();
+  _setRetryDelays([1, 1, 1]);
+  setSetting(MENU_GIST_SETTING_KEY, null);
+  delete process.env.ORACLE_MENU_GIST;
+  delete process.env.ORACLE_MENU_GIST_URL;
+}
+
+function restoreEnv() {
+  if (ORIG_ENV_GIST !== undefined) process.env.ORACLE_MENU_GIST = ORIG_ENV_GIST;
+  else delete process.env.ORACLE_MENU_GIST;
+  if (ORIG_ENV_GIST_URL !== undefined) process.env.ORACLE_MENU_GIST_URL = ORIG_ENV_GIST_URL;
+  else delete process.env.ORACLE_MENU_GIST_URL;
+}
+
+describe('POST /api/menu/source', () => {
+  beforeEach(() => {
+    resetAll();
+  });
+  afterEach(() => {
+    restoreFetch();
+    resetAll();
+    restoreEnv();
+  });
+
+  test('persists gist URL via settings and returns source', async () => {
+    globalThis.fetch = (async () => {
+      const res = new Response(JSON.stringify({ items: [] }), { status: 200 });
+      Object.defineProperty(res, 'url', {
+        value:
+          'https://gist.githubusercontent.com/natw/abcdef01/raw/aaaabbbbccccddddeeeeffff0000111122223333/menu.json',
+      });
+      return res;
+    }) as typeof fetch;
+
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://gist.github.com/natw/abcdef01' }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toBe('https://gist.github.com/natw/abcdef01');
+    expect(body.status).toBe('ok');
+    expect(body.hash).toBe('aaaabbbbccccddddeeeeffff0000111122223333');
+    expect(getSetting(MENU_GIST_SETTING_KEY)).toBe(
+      'https://gist.github.com/natw/abcdef01',
+    );
+  });
+
+  test('rejects invalid URL with 400', async () => {
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: 'https://not-a-gist.example.com/foo' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/invalid gist URL/i);
+    expect(getSetting(MENU_GIST_SETTING_KEY)).toBeNull();
+  });
+
+  test('rejects empty URL with 400', async () => {
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url: '   ' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/required/i);
+  });
+});
+
+describe('DELETE /api/menu/source', () => {
+  beforeEach(() => {
+    resetAll();
+  });
+  afterEach(() => {
+    restoreFetch();
+    resetAll();
+    restoreEnv();
+  });
+
+  test('clears gist URL from settings and returns status:none', async () => {
+    setSetting(MENU_GIST_SETTING_KEY, 'https://gist.github.com/natw/deadbeef01');
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    const res = await app.handle(
+      new Request('http://localhost/api/menu/source', { method: 'DELETE' }),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe('none');
+    expect(body.url).toBeNull();
+    expect(getSetting(MENU_GIST_SETTING_KEY)).toBeNull();
+  });
+});
+
+describe('GET /api/menu/source boot-read order', () => {
+  beforeEach(() => {
+    resetAll();
+  });
+  afterEach(() => {
+    restoreFetch();
+    resetAll();
+    restoreEnv();
+  });
+
+  test('settings row takes precedence over env var', async () => {
+    setSetting(MENU_GIST_SETTING_KEY, 'https://gist.github.com/natw/dbaadbaa01');
+    process.env.ORACLE_MENU_GIST_URL = 'https://gist.github.com/natw/efeffe0001';
+
+    let capturedUrl = '';
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    }) as typeof fetch;
+
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    await app.handle(new Request('http://localhost/api/menu'));
+    const res = await app.handle(new Request('http://localhost/api/menu/source'));
+    const body = await res.json();
+    expect(body.url).toBe('https://gist.github.com/natw/dbaadbaa01');
+    expect(capturedUrl).toContain('dbaadbaa01');
+  });
+
+  test('falls back to ORACLE_MENU_GIST_URL when settings empty', async () => {
+    process.env.ORACLE_MENU_GIST_URL = 'https://gist.github.com/natw/ebfa11bac01';
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ items: [] }), { status: 200 })) as typeof fetch;
+
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    await app.handle(new Request('http://localhost/api/menu'));
+    const res = await app.handle(new Request('http://localhost/api/menu/source'));
+    const body = await res.json();
+    expect(body.url).toBe('https://gist.github.com/natw/ebfa11bac01');
+  });
+
+  test('falls back to legacy ORACLE_MENU_GIST when others empty', async () => {
+    process.env.ORACLE_MENU_GIST = 'https://gist.github.com/natw/1e6ac1e0001';
+
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ items: [] }), { status: 200 })) as typeof fetch;
+
+    const app = new Elysia({ prefix: '/api' }).use(createMenuEndpoint());
+    await app.handle(new Request('http://localhost/api/menu'));
+    const res = await app.handle(new Request('http://localhost/api/menu/source'));
+    const body = await res.json();
+    expect(body.url).toBe('https://gist.github.com/natw/1e6ac1e0001');
+  });
+
+  test('getMenuConfig with no sources returns empty items and status:none', async () => {
+    const result = await getMenuConfig();
+    expect(result.items).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Part A of issue #929 — backend + CLI for gist URL menu source, persisted via settings table.

- **POST /api/menu/source** `{url}` — validates, persists via `setSetting('menu_gist_url', url)`, invalidates cache, reloads, returns source
- **DELETE /api/menu/source** — clears setting, returns `status:none`
- **src/menu/config.ts** — boot/reload now resolves gist URL in order: `settings.menu_gist_url` → `ORACLE_MENU_GIST_URL` → legacy `ORACLE_MENU_GIST`
- **CLI**: `arra-cli menu gist-url <url> | gist-clear | gist-reload | gist-status`

Drizzle-only (`getSetting`/`setSetting`). No raw SQL.

## Test plan
- [x] `tests/http/menu/gist-source.test.ts` — 8 cases: POST persist + returns source, POST rejects invalid/empty URL, DELETE clears, boot reads settings first, env_new fallback, legacy env fallback
- [x] `tests/cli/menu/gist.test.ts` — 5 cases: status/usage/invalid/round-trip/reload (spawns real server)
- [x] Full suite: **405 pass / 0 fail** (baseline 392+)
- [x] `tsc --noEmit` clean

Closes part A of #929. Part B (UI paste section) in follow-up.

🤖 ตอบโดย arra-oracle-v3 จาก Nat → arra-oracle-v3