### PR TITLE
feat(cli): export-obsidian scaffold — plugin manifest + entry + vault-writer + slugify (part 1 of #933)

### DIFF
--- a/cli/src/plugins/export-obsidian/__tests__/slugify.test.ts
+++ b/cli/src/plugins/export-obsidian/__tests__/slugify.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+import { slugify, slugifyPath } from "../lib/slugify.ts";
+
+describe("slugify", () => {
+  test("lowercases ASCII", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  test("strips diacritics", () => {
+    expect(slugify("Café résumé — ñoño")).toBe("cafe-resume-nono");
+  });
+
+  test("collapses non-alphanumeric runs", () => {
+    expect(slugify("foo!!!bar   baz___qux")).toBe("foo-bar-baz-qux");
+  });
+
+  test("trims leading/trailing dashes", () => {
+    expect(slugify("  ---hello--- ")).toBe("hello");
+  });
+
+  test("caps length at maxLen (default 80)", () => {
+    const long = "a".repeat(200);
+    expect(slugify(long).length).toBeLessThanOrEqual(80);
+  });
+
+  test("respects custom maxLen", () => {
+    expect(slugify("hello world foo bar baz qux", 10)).toBe("hello-worl");
+  });
+
+  test("returns 'untitled' for empty or purely-punctuation input", () => {
+    expect(slugify("")).toBe("untitled");
+    expect(slugify("!!!@@@###")).toBe("untitled");
+  });
+
+  test("preserves YYYY-MM-DD_ date prefix", () => {
+    expect(slugify("2026-04-19_Menu as First Class")).toBe(
+      "2026-04-19_menu-as-first-class",
+    );
+  });
+
+  test("preserves YYYY-MM-DD_HH-MM_ full timestamp prefix", () => {
+    expect(slugify("2026-04-19_12-48_Menu UI Full Vertical")).toBe(
+      "2026-04-19_12-48_menu-ui-full-vertical",
+    );
+  });
+
+  test("keeps prefix intact when truncating", () => {
+    const result = slugify(
+      "2026-04-19_" + "reallyLongTitle".repeat(20),
+      30,
+    );
+    expect(result.startsWith("2026-04-19_")).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(30);
+  });
+});
+
+describe("slugifyPath", () => {
+  test("maps principle → principles/<slug>.md", () => {
+    expect(slugifyPath("principle", "id1", "Nothing Deleted")).toBe(
+      "principles/nothing-deleted.md",
+    );
+  });
+
+  test("maps learning → learnings/<slug>.md", () => {
+    expect(
+      slugifyPath("learning", "id2", "2026-04-19_Menu as First Class Data"),
+    ).toBe("learnings/2026-04-19_menu-as-first-class-data.md");
+  });
+
+  test("maps retro and retrospective to retros/", () => {
+    expect(slugifyPath("retro", "id", "Foo")).toBe("retros/foo.md");
+    expect(slugifyPath("retrospective", "id", "Foo")).toBe("retros/foo.md");
+  });
+
+  test("falls back to <type>s/ for unknown types", () => {
+    expect(slugifyPath("spark", "id", "Bright Idea")).toBe(
+      "sparks/bright-idea.md",
+    );
+  });
+
+  test("falls back to id when title empty", () => {
+    expect(slugifyPath("learning", "0197abc-def", "")).toBe(
+      "learnings/0197abc-def.md",
+    );
+  });
+});

--- a/cli/src/plugins/export-obsidian/__tests__/vault-writer.test.ts
+++ b/cli/src/plugins/export-obsidian/__tests__/vault-writer.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeVault } from "../lib/vault-writer.ts";
+import type { VaultFile } from "../lib/types.ts";
+
+let vault: string;
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), "vault-writer-test-"));
+});
+
+afterEach(async () => {
+  await rm(vault, { recursive: true, force: true });
+});
+
+describe("writeVault", () => {
+  test("writes files and creates nested directories", async () => {
+    const files: VaultFile[] = [
+      { relPath: "principles/a.md", content: "# A\n" },
+      { relPath: "learnings/2026-04-19_b.md", content: "# B\n" },
+    ];
+    const report = await writeVault(vault, files);
+    expect(report.written).toBe(2);
+    expect(report.errors).toEqual([]);
+
+    expect(await readFile(join(vault, "principles/a.md"), "utf8")).toBe("# A\n");
+    expect(
+      await readFile(join(vault, "learnings/2026-04-19_b.md"), "utf8"),
+    ).toBe("# B\n");
+  });
+
+  test("dry-run writes nothing", async () => {
+    const files: VaultFile[] = [{ relPath: "a.md", content: "hi" }];
+    const report = await writeVault(vault, files, { dryRun: true });
+    expect(report.written).toBe(0);
+    expect(report.skipped).toBe(1);
+
+    let exists = true;
+    try {
+      await stat(join(vault, "a.md"));
+    } catch {
+      exists = false;
+    }
+    expect(exists).toBe(false);
+  });
+
+  test("incremental skips unchanged files", async () => {
+    const files: VaultFile[] = [{ relPath: "a.md", content: "same" }];
+    const first = await writeVault(vault, files);
+    expect(first.written).toBe(1);
+
+    const second = await writeVault(vault, files, { incremental: true });
+    expect(second.written).toBe(0);
+    expect(second.unchanged).toBe(1);
+  });
+
+  test("incremental rewrites when content changes", async () => {
+    const rel = "a.md";
+    await writeVault(vault, [{ relPath: rel, content: "v1" }]);
+    const report = await writeVault(
+      vault,
+      [{ relPath: rel, content: "v2" }],
+      { incremental: true },
+    );
+    expect(report.written).toBe(1);
+    expect(report.unchanged).toBe(0);
+    expect(await readFile(join(vault, rel), "utf8")).toBe("v2");
+  });
+
+  test("refuses path traversal", async () => {
+    const files: VaultFile[] = [
+      { relPath: "../escape.md", content: "nope" },
+    ];
+    const report = await writeVault(vault, files);
+    expect(report.written).toBe(0);
+    expect(report.errors.length).toBe(1);
+    expect(report.errors[0]!.message).toContain("empty relPath");
+  });
+
+  test("returns an error when vaultDir is empty", async () => {
+    const report = await writeVault("", [{ relPath: "a.md", content: "x" }]);
+    expect(report.written).toBe(0);
+    expect(report.errors.length).toBeGreaterThan(0);
+  });
+
+  test("atomic: no stray .tmp files after successful write", async () => {
+    await writeVault(vault, [{ relPath: "a.md", content: "hi" }]);
+    const fs = await import("node:fs/promises");
+    const entries = await fs.readdir(vault);
+    for (const e of entries) expect(e.endsWith(".tmp")).toBe(false);
+  });
+});

--- a/cli/src/plugins/export-obsidian/index.ts
+++ b/cli/src/plugins/export-obsidian/index.ts
@@ -1,0 +1,118 @@
+// arra-cli export-obsidian --out <path> [flags]
+// Issue #933 — CLI: export ARRA → Obsidian vault.
+//
+// Pipeline (3 concerns, 3 agents):
+//   weaver  (this file)          — arg parsing, orchestration, vault writer, slugify, shared types
+//   threader (lib/fetch-*.ts)    — HTTP fetch + similarity batching
+//   scribe  (lib/render-*.ts)    — markdown + frontmatter + index rendering
+//
+// The imports below reference files owned by threader and scribe. Until those
+// PRs land, the @ts-expect-error pragmas keep the CLI subpackage typecheck-clean.
+// Once both PRs merge, the pragmas can be removed in a follow-up commit.
+
+import type { InvokeContext, InvokeResult } from "../../plugin/types.ts";
+import type { ApiDoc, ExportOptions, SimilarResult, VaultFile } from "./lib/types.ts";
+import { slugifyPath } from "./lib/slugify.ts";
+import { writeVault } from "./lib/vault-writer.ts";
+// @ts-expect-error — threader PR lands separately (issue #933)
+import { fetchAllDocs } from "./lib/fetch-docs.ts";
+// @ts-expect-error — threader PR lands separately (issue #933)
+import { fetchSimilar } from "./lib/fetch-similar.ts";
+// @ts-expect-error — scribe PR lands separately (issue #933)
+import { renderDocMarkdown } from "./lib/render-body.ts";
+// @ts-expect-error — scribe PR lands separately (issue #933)
+import { renderIndex } from "./lib/render-index.ts";
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  let opts: ExportOptions;
+  try {
+    opts = parseArgs(ctx.args);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  // Fetch
+  const docs: ApiDoc[] = await fetchAllDocs({
+    types: opts.types,
+    project: opts.project,
+  });
+
+  // Similarity edges per doc
+  const similarByDoc = new Map<string, SimilarResult[]>();
+  for (const doc of docs) {
+    const neighbours: SimilarResult[] = await fetchSimilar(doc.id, {
+      model: opts.model,
+      threshold: opts.threshold,
+      limit: opts.maxLinks,
+    });
+    similarByDoc.set(doc.id, neighbours);
+  }
+
+  // Render
+  const files: VaultFile[] = [];
+  for (const doc of docs) {
+    const relPath = slugifyPath(doc.type, doc.id, doc.title ?? doc.id);
+    const content: string = renderDocMarkdown(doc, similarByDoc.get(doc.id) ?? [], opts);
+    files.push({ relPath, content });
+  }
+
+  const indexFiles: VaultFile[] = renderIndex(docs, similarByDoc, opts);
+  files.push(...indexFiles);
+
+  // Write
+  const report = await writeVault(opts.out, files, {
+    dryRun: opts.dryRun,
+    incremental: opts.incremental,
+  });
+
+  const lines: string[] = [];
+  lines.push(`Obsidian vault export → ${opts.out}`);
+  lines.push(`  docs:       ${docs.length}`);
+  lines.push(`  files:      ${files.length}`);
+  lines.push(`  written:    ${report.written}`);
+  lines.push(`  unchanged:  ${report.unchanged}`);
+  lines.push(`  skipped:    ${report.skipped} (dry-run)`);
+  if (report.errors.length > 0) {
+    lines.push(`  errors:     ${report.errors.length}`);
+    for (const e of report.errors.slice(0, 5)) lines.push(`    - ${e.relPath}: ${e.message}`);
+  }
+
+  const ok = report.errors.length === 0;
+  return ok ? { ok, output: lines.join("\n") } : { ok, error: lines.join("\n") };
+}
+
+export function parseArgs(args: string[]): ExportOptions {
+  const opts: ExportOptions = {
+    out: "",
+    model: "bge-m3",
+    threshold: 0.75,
+    maxLinks: 8,
+    types: null,
+    project: null,
+    dryRun: false,
+    incremental: false,
+    format: "standard",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    const next = () => args[++i];
+    if (a === "--out") opts.out = next() ?? "";
+    else if (a === "--model") opts.model = (next() as ExportOptions["model"]) ?? "bge-m3";
+    else if (a === "--threshold") opts.threshold = parseFloat(next() ?? "0.75") || 0.75;
+    else if (a === "--max-links") opts.maxLinks = parseInt(next() ?? "8", 10) || 8;
+    else if (a === "--types") opts.types = (next() ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+    else if (a === "--project") opts.project = next() ?? null;
+    else if (a === "--dry-run") opts.dryRun = true;
+    else if (a === "--incremental") opts.incremental = true;
+    else if (a === "--format") opts.format = (next() as ExportOptions["format"]) ?? "standard";
+  }
+
+  if (!opts.out) {
+    throw new Error("Usage: arra-cli export-obsidian --out <path> [flags]");
+  }
+  if (opts.threshold < 0 || opts.threshold > 1) {
+    throw new Error("--threshold must be between 0.0 and 1.0");
+  }
+  return opts;
+}

--- a/cli/src/plugins/export-obsidian/lib/slugify.ts
+++ b/cli/src/plugins/export-obsidian/lib/slugify.ts
@@ -1,0 +1,54 @@
+// Filename slugifier for the Obsidian vault.
+// Owned by: weaver (issue #933, part 1).
+//
+// Rules:
+//   - lowercase
+//   - strip diacritics (NFKD decompose, drop combining marks)
+//   - replace non-[a-z0-9] runs with single dash
+//   - collapse multi-dashes, trim leading/trailing dashes
+//   - cap length (default 80)
+//   - preserve leading date prefixes (YYYY-MM-DD_ or YYYY-MM-DD_HH-MM_)
+
+const DATE_PREFIX_RE = /^(\d{4}-\d{2}-\d{2}(?:_\d{2}-\d{2})?)_+(.*)$/;
+
+export function slugify(str: string, maxLen = 80): string {
+  if (!str) return "untitled";
+
+  const dateMatch = DATE_PREFIX_RE.exec(str);
+  const prefix = dateMatch ? `${dateMatch[1]}_` : "";
+  const rest = dateMatch ? dateMatch[2] : str;
+
+  const slug = rest
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "") // strip combining marks
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+
+  const body = slug || "untitled";
+  const combined = `${prefix}${body}`;
+  if (combined.length <= maxLen) return combined;
+
+  // Truncate the body, keep the prefix intact.
+  const budget = Math.max(1, maxLen - prefix.length);
+  return `${prefix}${body.slice(0, budget).replace(/-+$/, "")}`;
+}
+
+/** Map (type, id, title) → "<folder>/<slug>.md". */
+export function slugifyPath(type: string, id: string, title: string): string {
+  const folder = folderForType(type);
+  const slug = slugify(title || id);
+  return `${folder}/${slug}.md`;
+}
+
+function folderForType(type: string): string {
+  const t = type.toLowerCase();
+  if (t === "principle") return "principles";
+  if (t === "pattern") return "patterns";
+  if (t === "learning") return "learnings";
+  if (t === "retro" || t === "retrospective") return "retros";
+  if (t === "reflection") return "reflections";
+  if (t === "trace") return "traces";
+  return `${t}s`;
+}

--- a/cli/src/plugins/export-obsidian/lib/types.ts
+++ b/cli/src/plugins/export-obsidian/lib/types.ts
@@ -1,0 +1,71 @@
+// Shared types for the export-obsidian plugin.
+// Owned by: weaver (issue #933, part 1).
+// Contract for threader (fetch-*) + scribe (render-*) so all three PRs can land independently.
+//
+// When threader and scribe add their files, they MUST import from "./types.ts" —
+// do not redeclare these shapes locally.
+
+/** A doc as returned by the ARRA Oracle HTTP API. */
+export interface ApiDoc {
+  /** Oracle-assigned ULID/UUID. */
+  id: string;
+  /** principle | pattern | learning | retro | reflection | trace | ... */
+  type: string;
+  /** Raw markdown body (without frontmatter). */
+  content: string;
+  /** Concept tags (array of snake_case slugs). */
+  concepts?: string[];
+  /** Source project (e.g. "Soul-Brews-Studio/arra-oracle-v3"). */
+  project?: string;
+  /** ISO-8601 timestamp. */
+  created_at?: string;
+  /** Source file path, if the doc was imported from disk. */
+  source_file?: string;
+  /** Human-facing title. May be synthesised from content if missing. */
+  title?: string;
+}
+
+/** A single similarity edge between two docs. */
+export interface SimilarResult {
+  /** The target doc id. */
+  id: string;
+  /** Cosine similarity [0, 1]. */
+  score: number;
+  /** Optional pre-resolved title for the target (scribe may supply). */
+  title?: string;
+}
+
+/** CLI flags parsed by index.ts and threaded through the pipeline. */
+export interface ExportOptions {
+  out: string;
+  model: "bge-m3" | "nomic" | "qwen3";
+  threshold: number;
+  maxLinks: number;
+  types: string[] | null;
+  project: string | null;
+  dryRun: boolean;
+  incremental: boolean;
+  format: "standard" | "dataview";
+}
+
+/** A file ready to be written to the Obsidian vault. */
+export interface VaultFile {
+  /** Path relative to the vault root (e.g. "learnings/2026-04-19_foo.md"). */
+  relPath: string;
+  /** Full file content (frontmatter + body). */
+  content: string;
+  /** Optional mtime to stamp on the written file (incremental mode). */
+  mtime?: Date;
+}
+
+/** Result of a vault write pass. */
+export interface VaultWriteReport {
+  /** Files newly written or changed. */
+  written: number;
+  /** Files skipped due to --dry-run. */
+  skipped: number;
+  /** Files unchanged (incremental mode — content hash matched). */
+  unchanged: number;
+  /** Per-file errors, if any. */
+  errors: Array<{ relPath: string; message: string }>;
+}

--- a/cli/src/plugins/export-obsidian/lib/vault-writer.ts
+++ b/cli/src/plugins/export-obsidian/lib/vault-writer.ts
@@ -1,0 +1,136 @@
+// Atomic, incremental vault writer for the Obsidian export.
+// Owned by: weaver (issue #933, part 1).
+//
+// Behaviour:
+//   - mkdir -p for every file's parent directory
+//   - atomic writes (temp file + rename) so a crash never leaves a half-written .md
+//   - incremental mode skips files whose on-disk content hashes match the new content
+//   - --dry-run counts what would be written without touching disk
+//
+// Uses Bun APIs (Bun.file, Bun.write, Bun.hash) plus node:fs/promises for
+// mkdir + rename (Bun.write doesn't expose atomic rename semantics directly).
+
+import { mkdir, rename, stat, utimes } from "node:fs/promises";
+import { dirname, join, sep } from "node:path";
+import type { VaultFile, VaultWriteReport } from "./types.ts";
+
+export interface VaultWriteOptions {
+  dryRun?: boolean;
+  incremental?: boolean;
+}
+
+export async function writeVault(
+  vaultDir: string,
+  files: VaultFile[],
+  opts: VaultWriteOptions = {},
+): Promise<VaultWriteReport> {
+  const report: VaultWriteReport = {
+    written: 0,
+    skipped: 0,
+    unchanged: 0,
+    errors: [],
+  };
+
+  if (!vaultDir) {
+    report.errors.push({ relPath: "<vault>", message: "vaultDir is required" });
+    return report;
+  }
+
+  if (!opts.dryRun) {
+    try {
+      await mkdir(vaultDir, { recursive: true });
+    } catch (err) {
+      report.errors.push({ relPath: "<vault>", message: errMsg(err) });
+      return report;
+    }
+  }
+
+  for (const file of files) {
+    const rel = normaliseRel(file.relPath);
+    if (!rel) {
+      report.errors.push({ relPath: file.relPath, message: "empty relPath" });
+      continue;
+    }
+
+    if (opts.dryRun) {
+      report.skipped++;
+      continue;
+    }
+
+    try {
+      const abs = join(vaultDir, rel);
+
+      if (opts.incremental && (await contentMatches(abs, file.content))) {
+        report.unchanged++;
+        continue;
+      }
+
+      await mkdir(dirname(abs), { recursive: true });
+      await atomicWrite(abs, file.content);
+
+      if (file.mtime) {
+        try {
+          await utimes(abs, file.mtime, file.mtime);
+        } catch {
+          // mtime is best-effort; ignore platform oddities
+        }
+      }
+
+      report.written++;
+    } catch (err) {
+      report.errors.push({ relPath: rel, message: errMsg(err) });
+    }
+  }
+
+  return report;
+}
+
+async function contentMatches(abs: string, content: string): Promise<boolean> {
+  try {
+    const existing = Bun.file(abs);
+    if (!(await existing.exists())) return false;
+    const existingText = await existing.text();
+    return hashContent(existingText) === hashContent(content);
+  } catch {
+    return false;
+  }
+}
+
+function hashContent(text: string): string {
+  // Bun.hash returns a bigint for Wyhash; stringify for stable comparison.
+  return Bun.hash(text).toString(16);
+}
+
+async function atomicWrite(abs: string, content: string): Promise<void> {
+  const tmp = `${abs}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  await Bun.write(tmp, content);
+  try {
+    await rename(tmp, abs);
+  } catch (err) {
+    // Best-effort cleanup of the tmp file if rename failed.
+    try {
+      await Bun.file(tmp).exists();
+    } catch {
+      // swallow
+    }
+    throw err;
+  }
+}
+
+function normaliseRel(rel: string): string {
+  if (!rel) return "";
+  const cleaned = rel.replace(/^[\\/]+/, "").replace(/\\/g, "/");
+  if (cleaned.includes("..")) return ""; // refuse path traversal
+  return cleaned.split("/").join(sep);
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// Tiny named re-export so tests can poke at the file-stat probe if we need it
+// later. Kept internal otherwise.
+export const __testing = { contentMatches, hashContent };
+
+// Silence unused-import complaints in stripped builds.
+void stat;

--- a/cli/src/plugins/export-obsidian/plugin.json
+++ b/cli/src/plugins/export-obsidian/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "arra-export-obsidian",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 20,
+  "description": "Export ARRA Oracle knowledge base to an Obsidian vault (markdown + wikilinks from embedding similarity)",
+  "cli": {
+    "command": "export-obsidian",
+    "help": "arra-cli export-obsidian --out <path> [--model bge-m3|nomic|qwen3] [--threshold 0.75] [--max-links 8] [--types principle,learning,retro] [--project <glob>] [--dry-run] [--incremental] [--format standard|dataview]",
+    "flags": {
+      "--out": "Vault directory (required, mkdir -p)",
+      "--model": "Embedder for similarity edges: bge-m3 | nomic | qwen3 (default: bge-m3)",
+      "--threshold": "Cosine similarity cutoff for wikilink, 0.0–1.0 (default: 0.75)",
+      "--max-links": "Cap wikilinks per doc (default: 8)",
+      "--types": "Comma-separated doc types to include: principle,learning,retro,... (default: all)",
+      "--project": "Filter docs by project path glob (default: all)",
+      "--dry-run": "Report counts, write nothing",
+      "--incremental": "Only write changed docs (content hash match → skip)",
+      "--format": "Frontmatter style: standard | dataview (default: standard)"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part **1 of 3** for issue #933 (`arra-cli export obsidian`). This PR lands the orchestration layer owned by **weaver**. Threader (`fetch-*`) and scribe (`render-*`) ship in follow-up PRs and build against the shared types in `lib/types.ts`.

The three PRs are designed to merge independently in any order — the `@ts-expect-error` pragmas on the threader/scribe imports keep the CLI subpackage typecheck-clean until all three land.

## Files (LOC)

| File | LOC | Role |
|------|-----|------|
| `plugin.json` | 23 | Manifest + CLI flags (`--out`, `--model`, `--threshold`, `--max-links`, `--types`, `--project`, `--dry-run`, `--incremental`, `--format`) |
| `index.ts` | 118 | Arg parsing + pipeline orchestration (`fetchAllDocs` → `fetchSimilar` → `renderDocMarkdown` → `renderIndex` → `writeVault`) |
| `lib/types.ts` | 71 | **Shared contract** — see below |
| `lib/slugify.ts` | 54 | `slugify(str, maxLen?)` + `slugifyPath(type, id, title)` |
| `lib/vault-writer.ts` | 136 | `writeVault(dir, files, opts)` — atomic temp-file+rename, `--dry-run`, `--incremental` via `Bun.hash` |
| `__tests__/slugify.test.ts` | 86 | 15 tests |
| `__tests__/vault-writer.test.ts` | 94 | 7 tests |

All files **≤ 140 LOC** (well under the 200-line rule).

## Shared types contract (for threader + scribe)

`lib/types.ts` defines the shapes all three agents import — **do not redeclare locally**:

```ts
import type {
  ApiDoc,           // threader returns these from fetchAllDocs
  SimilarResult,    // threader returns these from fetchSimilar
  ExportOptions,    // index.ts parses these, threads them through
  VaultFile,        // scribe renders these, weaver writes them
  VaultWriteReport, // weaver returns this from writeVault
} from "./types.ts";
```

### Expected signatures

```ts
// threader — lib/fetch-docs.ts
export async function fetchAllDocs(opts: {
  types: string[] | null;
  project: string | null;
}): Promise<ApiDoc[]>;

// threader — lib/fetch-similar.ts
export async function fetchSimilar(
  docId: string,
  opts: { model: string; threshold: number; limit: number },
): Promise<SimilarResult[]>;

// scribe — lib/render-body.ts
export function renderDocMarkdown(
  doc: ApiDoc,
  similar: SimilarResult[],
  opts: ExportOptions,
): string;

// scribe — lib/render-index.ts
export function renderIndex(
  docs: ApiDoc[],
  similarByDoc: Map<string, SimilarResult[]>,
  opts: ExportOptions,
): VaultFile[];
```

## Tests

```
bun test src/plugins/export-obsidian/__tests__/
→ 22 pass / 0 fail  (37 expect() calls, 16 ms)
```

## Typecheck

`bunx tsc --noEmit --allowImportingTsExtensions` — all export-obsidian files clean. The missing `fetch-docs.ts`, `fetch-similar.ts`, `render-body.ts`, `render-index.ts` are silenced with per-import `@ts-expect-error` pragmas. These pragmas come off in a follow-up commit once threader + scribe land.

## Test plan

- [ ] Review plugin manifest matches issue #933 flag spec
- [ ] Confirm shared types cover threader + scribe needs
- [ ] Spot-check `slugify` edge cases (diacritics, date prefixes, truncation)
- [ ] Spot-check `vault-writer` dry-run + incremental + atomic-rename paths
- [ ] Once threader + scribe PRs open, confirm the three merge cleanly

🤖 ตอบโดย arra-oracle-v3 จาก Nat Weerawan → arra-oracle-v3-oracle