### PR TITLE
feat(cli): export-obsidian API client — fetch-docs + fetch-similar (part 2 of #933)

### DIFF
--- a/cli/src/plugins/export-obsidian/__tests__/fetch-docs.test.ts
+++ b/cli/src/plugins/export-obsidian/__tests__/fetch-docs.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for fetch-docs.ts — mocks global.fetch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { fetchAllDocs } from "../lib/fetch-docs.ts";
+import type { ApiDoc } from "../lib/types.ts";
+
+type FetchFn = typeof fetch;
+const originalFetch: FetchFn = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => { status?: number; body: unknown }) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const { status = 200, body } = handler(url);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as FetchFn;
+}
+
+function makeDoc(id: string, overrides: Partial<ApiDoc> = {}): ApiDoc {
+  return {
+    id,
+    type: "learning",
+    content: `content-${id}`,
+    source_file: `path/${id}.md`,
+    concepts: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("fetchAllDocs", () => {
+  it("returns an empty array when the server reports no docs", async () => {
+    mockFetch(() => ({ body: { results: [], total: 0 } }));
+    const docs = await fetchAllDocs();
+    expect(docs).toEqual([]);
+  });
+
+  it("paginates until a short page is received", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => makeDoc(`a${i}`));
+    const page2 = [makeDoc("last")];
+    let calls = 0;
+    mockFetch((url) => {
+      calls++;
+      if (url.includes("offset=0")) return { body: { results: page1, total: 101 } };
+      if (url.includes("offset=100")) return { body: { results: page2, total: 101 } };
+      throw new Error(`unexpected url: ${url}`);
+    });
+    const docs = await fetchAllDocs();
+    expect(docs).toHaveLength(101);
+    expect(calls).toBe(2);
+    expect(docs[docs.length - 1]!.id).toBe("last");
+  });
+
+  it("iterates once per requested type and dedupes by id", async () => {
+    const urls: string[] = [];
+    mockFetch((url) => {
+      urls.push(url);
+      if (url.includes("type=learning")) return { body: { results: [makeDoc("x")], total: 1 } };
+      if (url.includes("type=retro")) return { body: { results: [makeDoc("x"), makeDoc("y")], total: 2 } };
+      return { body: { results: [] } };
+    });
+    const docs = await fetchAllDocs({ types: ["learning", "retro"] });
+    expect(docs.map((d) => d.id).sort()).toEqual(["x", "y"]);
+    expect(urls.some((u) => u.includes("type=learning"))).toBe(true);
+    expect(urls.some((u) => u.includes("type=retro"))).toBe(true);
+  });
+
+  it("filters client-side by project glob", async () => {
+    mockFetch(() => ({
+      body: {
+        results: [
+          makeDoc("a", { project: "Soul-Brews-Studio/foo" }),
+          makeDoc("b", { project: "other/bar" }),
+          makeDoc("c", { project: "Soul-Brews-Studio/baz" }),
+        ],
+      },
+    }));
+    const docs = await fetchAllDocs({ project: "Soul-Brews-Studio/*" });
+    expect(docs.map((d) => d.id).sort()).toEqual(["a", "c"]);
+  });
+
+  it("throws on non-2xx responses", async () => {
+    mockFetch(() => ({ status: 500, body: { error: "boom" } }));
+    await expect(fetchAllDocs()).rejects.toThrow(/HTTP 500/);
+  });
+});

--- a/cli/src/plugins/export-obsidian/__tests__/fetch-similar.test.ts
+++ b/cli/src/plugins/export-obsidian/__tests__/fetch-similar.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for fetch-similar.ts — mocks global.fetch.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { fetchSimilar, fetchSimilarBatch } from "../lib/fetch-similar.ts";
+
+type FetchFn = typeof fetch;
+const originalFetch: FetchFn = globalThis.fetch;
+
+function mockFetch(handler: (url: string) => { status?: number; body: unknown }) {
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const { status = 200, body } = handler(url);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }) as FetchFn;
+}
+
+beforeEach(() => {
+  globalThis.fetch = originalFetch;
+});
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("fetchSimilar", () => {
+  it("returns empty array when server reports no neighbours", async () => {
+    mockFetch(() => ({ body: { results: [], docId: "root" } }));
+    const out = await fetchSimilar("root");
+    expect(out).toEqual([]);
+  });
+
+  it("drops self-matches and sub-threshold rows", async () => {
+    mockFetch(() => ({
+      body: {
+        results: [
+          { id: "root", score: 0.99, type: "learning", source_file: "self.md" },
+          { id: "a", score: 0.9, type: "learning", source_file: "a.md" },
+          { id: "b", score: 0.5, type: "retro", source_file: "b.md" },
+          { id: "c", score: 0.8, type: "learning", source_file: "c.md" },
+        ],
+      },
+    }));
+    const out = await fetchSimilar("root", { threshold: 0.75 });
+    expect(out.map((r) => r.id)).toEqual(["a", "c"]);
+    expect(out[0]!.score).toBe(0.9);
+    expect(out[0]!.type).toBe("learning");
+  });
+
+  it("forwards model + limit as query params", async () => {
+    let seen = "";
+    mockFetch((url) => {
+      seen = url;
+      return { body: { results: [] } };
+    });
+    await fetchSimilar("root", { model: "bge-m3", limit: 20 });
+    expect(seen).toContain("id=root");
+    expect(seen).toContain("limit=20");
+    expect(seen).toContain("model=bge-m3");
+  });
+
+  it("throws on HTTP error", async () => {
+    mockFetch(() => ({ status: 404, body: { error: "not found" } }));
+    await expect(fetchSimilar("missing")).rejects.toThrow(/HTTP 404/);
+  });
+});
+
+describe("fetchSimilarBatch", () => {
+  it("returns a Map keyed by input id", async () => {
+    mockFetch((url) => {
+      const m = url.match(/id=([^&]+)/);
+      const id = m ? m[1] : "";
+      return { body: { results: [{ id: `${id}-n`, score: 0.9 }] } };
+    });
+    const out = await fetchSimilarBatch(["a", "b"]);
+    expect(out.size).toBe(2);
+    expect(out.get("a")?.[0]?.id).toBe("a-n");
+    expect(out.get("b")?.[0]?.id).toBe("b-n");
+  });
+
+  it("fires onProgress once per doc in order", async () => {
+    mockFetch(() => ({ body: { results: [] } }));
+    const progress: Array<[number, number, string]> = [];
+    await fetchSimilarBatch(["x", "y", "z"], {
+      onProgress: (done, total, id) => progress.push([done, total, id]),
+    });
+    expect(progress).toEqual([
+      [1, 3, "x"],
+      [2, 3, "y"],
+      [3, 3, "z"],
+    ]);
+  });
+});

--- a/cli/src/plugins/export-obsidian/lib/fetch-docs.ts
+++ b/cli/src/plugins/export-obsidian/lib/fetch-docs.ts
@@ -1,0 +1,82 @@
+/**
+ * fetch-docs — paginated /api/list client for the export-obsidian plugin.
+ *
+ * Part 2 of issue #933 (threader agent).
+ *
+ * TODO(#933): switch imports to shared types once weaver's PR (part 1) lands.
+ */
+
+import { apiFetch } from "../../../lib/api.ts";
+import type { ApiDoc } from "./types.ts";
+
+const PAGE_SIZE = 100;
+
+export interface FetchDocsOptions {
+  /** Document types to include. Omit or pass empty array for all types. */
+  types?: string[];
+  /** Optional project glob — matched client-side against `ApiDoc.project`. */
+  project?: string;
+}
+
+interface ListResponse {
+  results?: ApiDoc[];
+  total?: number;
+  offset?: number;
+  limit?: number;
+}
+
+/**
+ * Fetch all documents matching the given filters, paginating until exhausted.
+ *
+ * - For each requested type (or a single "all" pass when `types` is omitted),
+ *   walks `/api/list?type=X&offset=N&limit=100` until the server returns
+ *   fewer results than `PAGE_SIZE` (or zero).
+ * - Applies the project glob client-side — the server does not filter on project.
+ */
+export async function fetchAllDocs(opts: FetchDocsOptions = {}): Promise<ApiDoc[]> {
+  const types = opts.types && opts.types.length > 0 ? opts.types : ["all"];
+  const projectMatcher = opts.project ? globToRegex(opts.project) : null;
+
+  const out: ApiDoc[] = [];
+  const seen = new Set<string>();
+
+  for (const type of types) {
+    let offset = 0;
+    // Hard cap to protect against runaway loops if the API misreports counts.
+    for (let guard = 0; guard < 10_000; guard++) {
+      const params = new URLSearchParams({
+        type,
+        offset: String(offset),
+        limit: String(PAGE_SIZE),
+      });
+      const res = await apiFetch(`/api/list?${params}`);
+      if (!res.ok) {
+        throw new Error(`fetchAllDocs: /api/list failed (type=${type}, offset=${offset}): HTTP ${res.status}`);
+      }
+      const body = (await res.json()) as ListResponse;
+      const page = body.results ?? [];
+      for (const doc of page) {
+        if (seen.has(doc.id)) continue;
+        if (projectMatcher && !projectMatcher.test(doc.project ?? "")) continue;
+        seen.add(doc.id);
+        out.push(doc);
+      }
+      if (page.length < PAGE_SIZE) break;
+      offset += PAGE_SIZE;
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Convert a simple glob (`*`, `?`) into a case-sensitive RegExp anchored on both ends.
+ * Escapes all other regex metacharacters.
+ */
+function globToRegex(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${escaped}$`);
+}

--- a/cli/src/plugins/export-obsidian/lib/fetch-similar.ts
+++ b/cli/src/plugins/export-obsidian/lib/fetch-similar.ts
@@ -1,0 +1,85 @@
+/**
+ * fetch-similar — vector nearest-neighbor client for the export-obsidian plugin.
+ *
+ * Part 2 of issue #933 (threader agent).
+ *
+ * Uses the existing `GET /api/similar?id=<docId>&limit=N&model=<m>` endpoint
+ * (see `src/routes/search/similar.ts`).
+ *
+ * TODO(#933): switch imports to shared types once weaver's PR (part 1) lands.
+ */
+
+import { apiFetch } from "../../../lib/api.ts";
+import type { SimilarResult } from "./types.ts";
+
+export interface FetchSimilarOptions {
+  /** Embedding model hint forwarded to the server (e.g. `bge-m3`). */
+  model?: string;
+  /** Max neighbours to request from the server before threshold filtering. */
+  limit?: number;
+  /** Client-side cosine-similarity cutoff (0..1). Results below are dropped. */
+  threshold?: number;
+}
+
+export interface FetchSimilarBatchOptions extends FetchSimilarOptions {
+  /** Optional progress callback — fired after each doc completes. */
+  onProgress?: (done: number, total: number, docId: string) => void;
+}
+
+interface SimilarResponseRow {
+  id: string;
+  score?: number;
+  type?: string;
+  source_file?: string;
+}
+interface SimilarResponse {
+  results?: SimilarResponseRow[];
+  docId?: string;
+}
+
+/** Fetch neighbours for a single doc id, filtered client-side by threshold. */
+export async function fetchSimilar(
+  docId: string,
+  opts: FetchSimilarOptions = {},
+): Promise<SimilarResult[]> {
+  const limit = opts.limit ?? 10;
+  const threshold = opts.threshold ?? 0;
+  const params = new URLSearchParams({ id: docId, limit: String(limit) });
+  if (opts.model) params.set("model", opts.model);
+
+  const res = await apiFetch(`/api/similar?${params}`);
+  if (!res.ok) {
+    throw new Error(`fetchSimilar: /api/similar failed (id=${docId}): HTTP ${res.status}`);
+  }
+  const body = (await res.json()) as SimilarResponse;
+  const rows = body.results ?? [];
+
+  const out: SimilarResult[] = [];
+  for (const r of rows) {
+    if (!r.id || r.id === docId) continue; // drop self-matches defensively
+    const score = typeof r.score === "number" ? r.score : 0;
+    if (score < threshold) continue;
+    out.push({ id: r.id, score, type: r.type, source_file: r.source_file });
+  }
+  return out;
+}
+
+/**
+ * Fetch neighbours for multiple doc ids sequentially.
+ * Returns a Map keyed by input doc id → its filtered SimilarResult list.
+ */
+export async function fetchSimilarBatch(
+  docIds: string[],
+  opts: FetchSimilarBatchOptions = {},
+): Promise<Map<string, SimilarResult[]>> {
+  const out = new Map<string, SimilarResult[]>();
+  const total = docIds.length;
+  let done = 0;
+  for (const id of docIds) {
+    const neighbours = await fetchSimilar(id, opts);
+    out.set(id, neighbours);
+    done++;
+    opts.onProgress?.(done, total, id);
+  }
+  return out;
+}

--- a/cli/src/plugins/export-obsidian/lib/types.ts
+++ b/cli/src/plugins/export-obsidian/lib/types.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared types for the export-obsidian plugin.
+ *
+ * TODO(#933): switch to shared types once weaver's PR (part 1) lands.
+ * This file is a placeholder written by the threader agent so that part 2
+ * (fetch-docs + fetch-similar) can compile standalone.
+ */
+
+/** A single document returned by `GET /api/list`. */
+export interface ApiDoc {
+  id: string;
+  type: string;
+  content: string;
+  source_file: string;
+  concepts: string[];
+  project?: string;
+  created_at?: string;
+  /** Some list responses use `indexed_at` instead of `created_at`. */
+  indexed_at?: string;
+}
+
+/** A single similarity match returned by `GET /api/similar` (or /api/search vector mode). */
+export interface SimilarResult {
+  id: string;
+  score: number;
+  type?: string;
+  source_file?: string;
+}


### PR DESCRIPTION
## Summary

Part 2 of issue #933 (CLI: export ARRA → Obsidian vault). Adds the API-client layer only — no writer, no CLI entry yet. Those land in later parts.

All files live under `cli/src/plugins/export-obsidian/lib/` and use the existing `cli/src/lib/api.ts` helper for HTTP.

### Exported functions

**`lib/fetch-docs.ts`** (82 LOC, cap 120)
- `fetchAllDocs(opts: { types?: string[]; project?: string }): Promise<ApiDoc[]>`
  - Paginates `GET /api/list?type=X&offset=N&limit=100` until a short page is returned.
  - Walks each requested type once (or `"all"` if none given).
  - Dedupes by `id`, filters by project glob (`*`, `?`) client-side.

**`lib/fetch-similar.ts`** (85 LOC, cap 100)
- `fetchSimilar(docId, opts: { model?, limit?, threshold? }): Promise<SimilarResult[]>`
  - Wraps `GET /api/similar?id=<docId>&limit=N&model=<m>` — the existing route at `src/routes/search/similar.ts`.
  - Drops self-matches defensively, filters by client-side threshold.
- `fetchSimilarBatch(docIds, opts & { onProgress? }): Promise<Map<string, SimilarResult[]>>`
  - Sequential (`/api/similar` is single-id); fires `onProgress(done, total, id)` after each.

**`lib/types.ts`** (28 LOC)
- Placeholder `ApiDoc` and `SimilarResult` interfaces. Weaver's part-1 PR hasn't merged yet, so these ship inline with a `TODO(#933)` comment. Post-merge we flip the imports to the shared types.

### Example usage (inside later parts of #933)

```ts
import { fetchAllDocs } from "./lib/fetch-docs.ts";
import { fetchSimilarBatch } from "./lib/fetch-similar.ts";

const docs = await fetchAllDocs({
  types: ["principle", "learning", "retro"],
  project: "Soul-Brews-Studio/*",
});

const neighbours = await fetchSimilarBatch(
  docs.map((d) => d.id),
  {
    model: "bge-m3",
    limit: 10,
    threshold: 0.75,
    onProgress: (done, total) => console.log(`${done}/${total}`),
  },
);
```

### Tests — 11 pass, 0 fail

`bun test cli/src/plugins/export-obsidian/__tests__/`

- `fetch-docs.test.ts` (5 tests): empty response, pagination until short page, multi-type iteration + dedup, project glob filter, HTTP error.
- `fetch-similar.test.ts` (6 tests): empty, self-match + threshold drop, query-param forwarding, HTTP error, batch Map return, `onProgress` order.

All tests mock `global.fetch`.

### Scope discipline

- Files ≤200 LOC (actual caps 120/100/unbounded; all well under).
- No new dependencies.
- Tied to only the two files under `cli/src/plugins/export-obsidian/lib/` plus their `__tests__/`.

## Test plan

- [x] `bun test cli/src/plugins/export-obsidian/__tests__/` — 11/11 pass locally.
- [x] `bunx tsc --noEmit` clean against our files using repo's bun/tsconfig flags (`allowImportingTsExtensions` in root `tsconfig.json`).
- [ ] Reviewer: wire these into the writer once weaver's part-1 PR merges — flip `./types.ts` → shared types module.

🤖 ตอบโดย arra-oracle-v3 จาก Nat Weerawan → arra-oracle-v3-oracle