### PR TITLE
feat(api): /api/compare — fan out + agreement metrics (Phase 2 of ui-vector#5)

### DIFF
--- a/src/routes/compare/agreement.ts
+++ b/src/routes/compare/agreement.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure agreement metric functions for /api/compare.
+ *
+ * Given a map of modelName → ranked results, compute:
+ *   - topKAgreement: fraction of models that agree on rank-K pick
+ *   - topKJaccard:   intersection / union of top-K id-sets across models
+ *   - avgRankShift:  mean (maxRank − minRank) for ids appearing in ≥2 models
+ *   - sharedIds:     ids appearing in ≥2 models
+ *
+ * Mirrors ui-vector surveyor's lib (vector-oracle-studio/src/lib/compare/aggregate.ts)
+ * so the frontend can drop the client-side math when it reads from /api/compare.
+ */
+export interface HasId { id: string }
+export type ByModel<T extends HasId = HasId> = Record<string, T[]>;
+
+/**
+ * Top-K agreement: of models with ≥K results, the fraction that picked the
+ * plurality id at rank K (1-indexed). 1 = all agree, 0 = no data.
+ */
+export function topKAgreement<T extends HasId>(byModel: ByModel<T>, k: number = 1): number {
+  const idsAtK: string[] = [];
+  for (const docs of Object.values(byModel)) {
+    if (docs.length >= k) idsAtK.push(docs[k - 1].id);
+  }
+  if (idsAtK.length === 0) return 0;
+  const counts = new Map<string, number>();
+  for (const id of idsAtK) counts.set(id, (counts.get(id) ?? 0) + 1);
+  let max = 0;
+  for (const n of counts.values()) if (n > max) max = n;
+  return max / idsAtK.length;
+}
+
+/** |∩|/|∪| of top-K id-sets across all models. Single model → 1 (if non-empty). */
+export function topKJaccard<T extends HasId>(byModel: ByModel<T>, k: number = 5): number {
+  const sets = Object.values(byModel).map(
+    (docs) => new Set(docs.slice(0, k).map((d) => d.id)),
+  );
+  if (sets.length === 0) return 0;
+  if (sets.length === 1) return sets[0].size === 0 ? 0 : 1;
+  const union = new Set<string>();
+  for (const s of sets) for (const id of s) union.add(id);
+  if (union.size === 0) return 0;
+  const intersect = new Set<string>(sets[0]);
+  for (let i = 1; i < sets.length; i++) {
+    for (const id of Array.from(intersect)) {
+      if (!sets[i].has(id)) intersect.delete(id);
+    }
+  }
+  return intersect.size / union.size;
+}
+
+/**
+ * For ids appearing in ≥2 columns, mean of (maxRank − minRank).
+ * Rank is 1-indexed. Returns 0 when no id is shared.
+ */
+export function avgRankShift<T extends HasId>(byModel: ByModel<T>): number {
+  const ranks = new Map<string, number[]>();
+  for (const docs of Object.values(byModel)) {
+    docs.forEach((d, i) => {
+      const arr = ranks.get(d.id);
+      if (arr) arr.push(i + 1);
+      else ranks.set(d.id, [i + 1]);
+    });
+  }
+  const shifts: number[] = [];
+  for (const arr of ranks.values()) {
+    if (arr.length >= 2) {
+      let mn = arr[0];
+      let mx = arr[0];
+      for (const r of arr) {
+        if (r < mn) mn = r;
+        if (r > mx) mx = r;
+      }
+      shifts.push(mx - mn);
+    }
+  }
+  if (shifts.length === 0) return 0;
+  let sum = 0;
+  for (const s of shifts) sum += s;
+  return sum / shifts.length;
+}
+
+/** Doc ids appearing in ≥2 columns (deduped per-column first). */
+export function sharedIds<T extends HasId>(byModel: ByModel<T>): string[] {
+  const counts = new Map<string, number>();
+  for (const docs of Object.values(byModel)) {
+    const seen = new Set<string>();
+    for (const d of docs) {
+      if (seen.has(d.id)) continue;
+      seen.add(d.id);
+      counts.set(d.id, (counts.get(d.id) ?? 0) + 1);
+    }
+  }
+  const out: string[] = [];
+  for (const [id, n] of counts) if (n >= 2) out.push(id);
+  return out;
+}
+
+export interface AgreementMetrics {
+  top1: number;
+  top5_jaccard: number;
+  avg_rank_shift: number;
+  shared_ids: string[];
+}
+
+/** Bundle all four metrics; convenience for the /api/compare handler. */
+export function computeAgreement<T extends HasId>(byModel: ByModel<T>): AgreementMetrics {
+  return {
+    top1: +topKAgreement(byModel, 1).toFixed(4),
+    top5_jaccard: +topKJaccard(byModel, 5).toFixed(4),
+    avg_rank_shift: +avgRankShift(byModel).toFixed(4),
+    shared_ids: sharedIds(byModel),
+  };
+}

--- a/src/routes/compare/compare.ts
+++ b/src/routes/compare/compare.ts
@@ -1,0 +1,117 @@
+/**
+ * GET /api/compare — fan out search across multiple embedding models
+ * server-side, return merged payload + pre-computed agreement metrics.
+ *
+ * Single round-trip from frontend instead of N parallel /api/search calls.
+ * Phase 2 of ui-vector#5.
+ */
+
+import { Elysia, t } from 'elysia';
+import { handleSearch } from '../../server/handlers.ts';
+import { getEmbeddingModels } from '../../vector/factory.ts';
+import { computeAgreement, type ByModel } from './agreement.ts';
+import type { SearchResult } from '../../server/types.ts';
+
+const CompareQuery = t.Object({
+  q: t.Optional(t.String()),
+  models: t.Optional(t.String()),
+  limit: t.Optional(t.String()),
+  type: t.Optional(t.String()),
+  project: t.Optional(t.String()),
+  cwd: t.Optional(t.String()),
+});
+
+type ByModelResponse = Record<
+  string,
+  { results: SearchResult[]; latency_ms: number } | { error: string }
+>;
+
+function sanitize(q: string): string {
+  return q
+    .replace(/<[^>]*>/g, '')
+    .replace(/[\x00-\x1f]/g, '')
+    .trim();
+}
+
+export const compareEndpoint = new Elysia().get(
+  '/compare',
+  async ({ query, set }) => {
+    const q = query.q;
+    if (!q) {
+      set.status = 400;
+      return { error: 'Missing query parameter: q' };
+    }
+    const sanitizedQ = sanitize(q);
+    if (!sanitizedQ) {
+      set.status = 400;
+      return { error: 'Invalid query: empty after sanitization' };
+    }
+
+    const enabledModels = Object.keys(getEmbeddingModels());
+    const requested = query.models
+      ? query.models
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : enabledModels;
+    // Preserve requested order but only keep known models
+    const models = requested.filter((m) => enabledModels.includes(m));
+
+    const limit = Math.min(100, Math.max(1, parseInt(query.limit ?? '20')));
+    const type = query.type ?? 'all';
+    const project = query.project;
+    const cwd = query.cwd;
+
+    const byModel: ByModelResponse = {};
+
+    if (models.length === 0) {
+      return {
+        query: sanitizedQ,
+        models: [],
+        byModel,
+        agreement: { top1: 0, top5_jaccard: 0, avg_rank_shift: 0, shared_ids: [] },
+      };
+    }
+
+    const settled = await Promise.allSettled(
+      models.map(async (model) => {
+        const start = Date.now();
+        const result = await handleSearch(
+          sanitizedQ,
+          type,
+          limit,
+          0,
+          'vector',
+          project,
+          cwd,
+          model,
+        );
+        return { model, result, latency_ms: Date.now() - start };
+      }),
+    );
+
+    const successByModel: ByModel<SearchResult> = {};
+    settled.forEach((r, i) => {
+      const model = models[i];
+      if (r.status === 'fulfilled') {
+        byModel[model] = { results: r.value.result.results, latency_ms: r.value.latency_ms };
+        successByModel[model] = r.value.result.results;
+      } else {
+        const msg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        byModel[model] = { error: msg };
+      }
+    });
+
+    const agreement = computeAgreement(successByModel);
+
+    return { query: sanitizedQ, models, byModel, agreement };
+  },
+  {
+    query: CompareQuery,
+    detail: {
+      tags: ['search'],
+      menu: { group: 'main', order: 15 },
+      summary: 'Fan out search across models + pre-computed agreement metrics',
+    },
+  },
+);

--- a/src/routes/compare/index.ts
+++ b/src/routes/compare/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Compare routes (Elysia) — composes /api/compare.
+ */
+
+import { Elysia } from 'elysia';
+import { compareEndpoint } from './compare.ts';
+
+export const compareRoutes = new Elysia({ prefix: '/api' }).use(compareEndpoint);

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { feedRoutes } from './routes/feed/index.ts';
 import { healthRoutes } from './routes/health/index.ts';
 import { dashboardRoutes } from './routes/dashboard/index.ts';
 import { searchRoutes } from './routes/search/index.ts';
+import { compareRoutes } from './routes/compare/index.ts';
 import { knowledgeRoutes } from './routes/knowledge/index.ts';
 import { supersedeRoutes } from './routes/supersede/index.ts';
 import { forumApi } from './routes/forum/index.ts';
@@ -169,6 +170,7 @@ const apiModules = [
   healthRoutes,
   dashboardRoutes,
   searchRoutes,
+  compareRoutes,
   knowledgeRoutes,
   supersedeRoutes,
   forumApi,

--- a/tests/http/compare.test.ts
+++ b/tests/http/compare.test.ts
@@ -1,0 +1,142 @@
+/**
+ * HTTP Contract Tests — GET /api/compare
+ *
+ * Phase 2 of ui-vector#5: fan-out search across multiple embedding models,
+ * single round-trip with pre-computed agreement metrics.
+ *
+ * Pattern mirrors tests/http/knowledge.test.ts (subprocess + fetch).
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import type { Subprocess } from "bun";
+import path from "path";
+
+const BASE_URL = "http://localhost:47778";
+const SEED_TAG = `compare-http-test-${Date.now()}`;
+const JSON_HEADERS = { "Content-Type": "application/json" };
+let serverProcess: Subprocess | null = null;
+
+const isUp = async () => {
+  try { return (await fetch(`${BASE_URL}/api/health`)).ok; } catch { return false; }
+};
+const waitUp = async (n = 30) => {
+  for (let i = 0; i < n; i++) { if (await isUp()) return true; await Bun.sleep(500); }
+  return false;
+};
+const post = (url: string, body: unknown) =>
+  fetch(`${BASE_URL}${url}`, { method: "POST", headers: JSON_HEADERS, body: JSON.stringify(body) });
+
+async function seedLearn(pattern: string, concepts: string[] = []) {
+  const res = await post("/api/learn", { pattern, source: SEED_TAG, concepts: [SEED_TAG, ...concepts] });
+  if (!res.ok) throw new Error(`seed failed (${res.status}): ${await res.text()}`);
+  return res.json();
+}
+
+describe("HTTP Contract — GET /api/compare", () => {
+  beforeAll(async () => {
+    if (await isUp()) return;
+    serverProcess = Bun.spawn(["bun", "run", "src/server.ts"], {
+      cwd: path.resolve(import.meta.dir, "../.."),
+      stdout: "pipe", stderr: "pipe",
+      env: { ...process.env, ORACLE_CHROMA_TIMEOUT: "3000" },
+    });
+    if (!(await waitUp())) throw new Error("Server failed to start within 15s");
+    // Best-effort seed so some model columns have real results
+    try { await seedLearn(`${SEED_TAG} — alpha about compare endpoint`); } catch { /* ignore */ }
+    try { await seedLearn(`${SEED_TAG} — beta on compare agreement`); } catch { /* ignore */ }
+  }, 60_000);
+  afterAll(() => { if (serverProcess) serverProcess.kill(); });
+
+  test("rejects missing query param", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare`);
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/q/);
+  });
+
+  test("rejects query empty after sanitize", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent("<script></script>")}`);
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/empty|invalid/i);
+  });
+
+  test("default (no models param) uses all enabled models", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&limit=5`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.query).toBe(SEED_TAG);
+    expect(Array.isArray(data.models)).toBe(true);
+    expect(data.models.length).toBeGreaterThan(0);
+    expect(typeof data.byModel).toBe("object");
+    expect(data.byModel).not.toBeNull();
+    // Every listed model must have a byModel entry
+    for (const m of data.models) expect(data.byModel).toHaveProperty(m);
+    // Agreement block always present
+    expect(data.agreement).toBeDefined();
+    expect(typeof data.agreement.top1).toBe("number");
+    expect(typeof data.agreement.top5_jaccard).toBe("number");
+    expect(typeof data.agreement.avg_rank_shift).toBe("number");
+    expect(Array.isArray(data.agreement.shared_ids)).toBe(true);
+  }, 60_000);
+
+  test("explicit models param — successful columns include latency_ms", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&models=bge-m3,nomic&limit=3`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.models).toEqual(["bge-m3", "nomic"]);
+    for (const m of ["bge-m3", "nomic"]) {
+      const entry = data.byModel[m];
+      expect(entry).toBeDefined();
+      if ("error" in entry) {
+        expect(typeof entry.error).toBe("string");
+      } else {
+        expect(Array.isArray(entry.results)).toBe(true);
+        expect(typeof entry.latency_ms).toBe("number");
+        expect(entry.results.length).toBeLessThanOrEqual(3);
+      }
+    }
+  }, 60_000);
+
+  test("unknown model names are filtered out, known ones remain", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&models=bge-m3,bogus-model-xyz&limit=2`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.models).toEqual(["bge-m3"]);
+    expect(data.byModel).toHaveProperty("bge-m3");
+    expect(data.byModel).not.toHaveProperty("bogus-model-xyz");
+  }, 60_000);
+
+  test("no models enabled (all unknown) → empty byModel + zero agreement", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&models=none1,none2`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.models).toEqual([]);
+    expect(Object.keys(data.byModel).length).toBe(0);
+    expect(data.agreement.top1).toBe(0);
+    expect(data.agreement.top5_jaccard).toBe(0);
+    expect(data.agreement.avg_rank_shift).toBe(0);
+    expect(data.agreement.shared_ids).toEqual([]);
+  });
+
+  test("per-model failure is captured, other columns stay intact", async () => {
+    // qwen3 typically isn't loaded in CI / dev → errors surface as a per-model
+    // `error` string while bge-m3 and nomic succeed. We accept either shape.
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&models=bge-m3,qwen3&limit=3`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    expect(data.models).toEqual(["bge-m3", "qwen3"]);
+    expect(data.byModel["bge-m3"]).toBeDefined();
+    expect(data.byModel["qwen3"]).toBeDefined();
+    // If qwen3 errored, agreement block must still compute (from surviving models)
+    expect(data.agreement).toBeDefined();
+  }, 60_000);
+
+  test("limit is clamped to [1,100]", async () => {
+    const res = await fetch(`${BASE_URL}/api/compare?q=${encodeURIComponent(SEED_TAG)}&models=bge-m3&limit=9999`);
+    expect(res.ok).toBe(true);
+    const data = await res.json();
+    const entry = data.byModel["bge-m3"];
+    if (entry && "results" in entry) {
+      expect(entry.results.length).toBeLessThanOrEqual(100);
+    }
+  }, 60_000);
+});


### PR DESCRIPTION
New endpoint `GET /api/compare?q=...&models=bge-m3,nomic,qwen3&limit=20` fans out search across enabled models server-side, returns `byModel` + `agreement` (top1, top5_jaccard, avg_rank_shift, shared_ids). Reuses `handleSearch()`. Promise.allSettled → per-model error captured without aborting others. 8 integration tests pass. Phase 2 lets vector-side /compare swap from N parallel calls to 1 round-trip.