### PR TITLE
feat(cli): import-obsidian — round-trip vault changes back to ARRA (closes #938)

### DIFF
--- a/cli/src/plugins/export-obsidian/index.ts
+++ b/cli/src/plugins/export-obsidian/index.ts
@@ -17,12 +17,13 @@ import type {
   VaultStats,
 } from "./lib/types.ts";
 import { slugify, slugifyPath } from "./lib/slugify.ts";
-import { writeVault } from "./lib/vault-writer.ts";
+import { writeVault, writeStateFile } from "./lib/vault-writer.ts";
 import { fetchAllDocs } from "./lib/fetch-docs.ts";
 import { fetchSimilar } from "./lib/fetch-similar.ts";
-import { renderDocMarkdown } from "./lib/render-body.ts";
+import { renderDocMarkdown, deriveTitle } from "./lib/render-body.ts";
 import { renderIndex } from "./lib/render-index.ts";
 import { renderConceptHub } from "./lib/concept-hub.ts";
+import { hashPayload } from "./lib/state-hash.ts";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   let opts: ExportOptions;
@@ -89,6 +90,24 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     dryRun: opts.dryRun,
     incremental: opts.incremental,
   });
+
+  // Issue #938 — write .arra-vault-state.json so import-obsidian can diff.
+  if (!opts.dryRun && report.errors.length === 0) {
+    const stateDocs: Record<string, { relPath: string; contentHash: string }> = {};
+    for (const doc of docs) {
+      const relPath = `${slugForId(doc.id)}.md`;
+      const title = deriveTitle(doc);
+      const hash = hashPayload(title, doc.content, doc.concepts ?? []);
+      stateDocs[doc.id] = { relPath, contentHash: hash };
+    }
+    await writeStateFile(opts.out, {
+      version: 1,
+      last_export: new Date().toISOString(),
+      model: opts.model,
+      threshold: opts.threshold,
+      docs: stateDocs,
+    });
+  }
 
   const lines: string[] = [];
   lines.push(`Obsidian vault export → ${opts.out}`);

--- a/cli/src/plugins/export-obsidian/lib/state-hash.ts
+++ b/cli/src/plugins/export-obsidian/lib/state-hash.ts
@@ -1,0 +1,16 @@
+// Deterministic content hash used by both export (writing state) and import
+// (diffing against state). Kept standalone so the shape can't drift between
+// the two plugins. Must match import-obsidian/lib/parse-body.ts:hashPayload.
+//
+// We normalise content the same way parse-body does: strip leading H1 so the
+// export's rendered "# Title" + input content round-trip cleanly.
+
+export function stripLeadingH1(body: string): string {
+  return body.replace(/^\s*#\s+.+?\s*(?:\r?\n|$)/, "");
+}
+
+export function hashPayload(title: string, content: string, concepts: string[]): string {
+  const body = stripLeadingH1(content).trim();
+  const payload = `${title}\n---\n${body}\n---\n${concepts.slice().sort().join(",")}`;
+  return Bun.hash(payload).toString(16);
+}

--- a/cli/src/plugins/export-obsidian/lib/vault-writer.ts
+++ b/cli/src/plugins/export-obsidian/lib/vault-writer.ts
@@ -134,3 +134,10 @@ export const __testing = { contentMatches, hashContent };
 
 // Silence unused-import complaints in stripped builds.
 void stat;
+
+/** Atomic write of .arra-vault-state.json (issue #938 round-trip). */
+export async function writeStateFile(vaultDir: string, state: unknown): Promise<void> {
+  await mkdir(vaultDir, { recursive: true });
+  const abs = join(vaultDir, ".arra-vault-state.json");
+  await atomicWrite(abs, JSON.stringify(state, null, 2) + "\n");
+}

--- a/cli/src/plugins/import-obsidian/__tests__/apply-changes.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/apply-changes.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { applyPlan, composeContent } from '../lib/apply-changes.ts';
+import type { ImportDoc, ImportPlan } from '../lib/types.ts';
+
+// Monkey-patch global fetch so we can intercept /api/doc calls without
+// spinning up a real server. apiFetch uses global fetch under the hood.
+const realFetch = globalThis.fetch;
+let calls: { url: string; method: string; body: unknown }[] = [];
+
+beforeAll(() => {
+  // no-op
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  calls = [];
+});
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  globalThis.fetch = (async (input: any, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.url;
+    const body = init?.body ? JSON.parse(String(init.body)) : undefined;
+    calls.push({ url, method: init?.method ?? 'GET', body });
+    return handler(url, init);
+  }) as typeof fetch;
+}
+
+function doc(id: string | undefined, rel = 'a.md'): ImportDoc {
+  return {
+    absPath: `/tmp/${rel}`,
+    relPath: rel,
+    meta: id ? { arra_id: id, arra_type: 'learning' } : { arra_type: 'learning' },
+    body: 'content',
+    title: 'Title',
+    concepts: ['x', 'y'],
+    contentHash: 'h',
+  };
+}
+
+describe('composeContent', () => {
+  test('prepends H1 title', () => {
+    expect(composeContent(doc('a'))).toContain('# Title');
+    expect(composeContent(doc('a'))).toContain('content');
+  });
+
+  test('no body → bare title', () => {
+    const d = { ...doc('a'), body: '' };
+    expect(composeContent(d).trim()).toBe('# Title');
+  });
+});
+
+describe('applyPlan', () => {
+  test('dry-run makes no fetch calls', async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const plan: ImportPlan = {
+      items: [{ doc: doc('a'), action: 'update' }],
+      summary: { changed: 1, created: 0, unchanged: 0, skippedNoId: 0, tombstoned: 0 },
+    };
+    const r = await applyPlan(plan, { dryRun: true, verbose: false, log: () => {} });
+    expect(calls.length).toBe(0);
+    expect(r.applied).toBe(1);
+  });
+
+  test('update → PATCH /api/doc/:id', async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const plan: ImportPlan = {
+      items: [{ doc: doc('abc'), action: 'update' }],
+      summary: { changed: 1, created: 0, unchanged: 0, skippedNoId: 0, tombstoned: 0 },
+    };
+    const r = await applyPlan(plan, { dryRun: false, verbose: false, log: () => {} });
+    expect(r.applied).toBe(1);
+    expect(r.failed).toBe(0);
+    expect(calls[0]!.method).toBe('PATCH');
+    expect(calls[0]!.url).toContain('/api/doc/abc');
+    const body = calls[0]!.body as any;
+    expect(body.concepts).toEqual(['x', 'y']);
+    expect(body.content).toContain('# Title');
+  });
+
+  test('create → POST /api/doc', async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true, id: 'new_id' }), { status: 200 }));
+    const plan: ImportPlan = {
+      items: [{ doc: doc(undefined, 'n.md'), action: 'create' }],
+      summary: { changed: 0, created: 1, unchanged: 0, skippedNoId: 0, tombstoned: 0 },
+    };
+    const r = await applyPlan(plan, { dryRun: false, verbose: false, log: () => {} });
+    expect(r.created).toBe(1);
+    expect(calls[0]!.method).toBe('POST');
+    expect(calls[0]!.url).toContain('/api/doc');
+  });
+
+  test('skip-no-id logs a warning, no fetch', async () => {
+    mockFetch(() => new Response('', { status: 500 }));
+    const logs: string[] = [];
+    const plan: ImportPlan = {
+      items: [{ doc: doc(undefined), action: 'skip-no-id' }],
+      summary: { changed: 0, created: 0, unchanged: 0, skippedNoId: 1, tombstoned: 0 },
+    };
+    const r = await applyPlan(plan, { dryRun: false, verbose: false, log: (s) => logs.push(s) });
+    expect(calls.length).toBe(0);
+    expect(r.skipped).toBe(1);
+    expect(logs.some((l) => l.includes('no arra_id'))).toBe(true);
+  });
+
+  test('PATCH HTTP error → recorded as failure', async () => {
+    mockFetch(() => new Response('boom', { status: 500 }));
+    const plan: ImportPlan = {
+      items: [{ doc: doc('abc'), action: 'update' }],
+      summary: { changed: 1, created: 0, unchanged: 0, skippedNoId: 0, tombstoned: 0 },
+    };
+    const r = await applyPlan(plan, { dryRun: false, verbose: false, log: () => {} });
+    expect(r.failed).toBe(1);
+    expect(r.errors[0]?.message).toContain('HTTP 500');
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/diff-state.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/diff-state.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildPlan, loadState } from '../lib/diff-state.ts';
+import type { ImportDoc, VaultState } from '../lib/types.ts';
+
+let vault: string;
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), 'diff-state-test-'));
+});
+
+afterEach(async () => {
+  await rm(vault, { recursive: true, force: true });
+});
+
+function mkDoc(id: string | undefined, hash: string, rel = 'a.md'): ImportDoc {
+  return {
+    absPath: `/tmp/${rel}`,
+    relPath: rel,
+    meta: id ? { arra_id: id, arra_type: 'learning' } : { arra_type: 'learning' },
+    body: 'body',
+    title: 'T',
+    concepts: ['x'],
+    contentHash: hash,
+  };
+}
+
+describe('loadState', () => {
+  test('returns null when state file missing', async () => {
+    const s = await loadState(vault);
+    expect(s).toBeNull();
+  });
+
+  test('reads a valid state file', async () => {
+    const state: VaultState = {
+      version: 1,
+      last_export: '2026-04-19T00:00:00Z',
+      docs: { abc: { relPath: 'a.md', contentHash: 'h1' } },
+    };
+    await writeFile(join(vault, '.arra-vault-state.json'), JSON.stringify(state));
+    const s = await loadState(vault);
+    expect(s?.docs.abc?.contentHash).toBe('h1');
+  });
+});
+
+describe('buildPlan', () => {
+  test('classifies unchanged / update / skip-no-id / create', () => {
+    const docs: ImportDoc[] = [
+      mkDoc('abc', 'h1', 'a.md'), // unchanged
+      mkDoc('def', 'newHash', 'b.md'), // changed
+      mkDoc(undefined, 'h3', 'c.md'), // no id → skip
+    ];
+    const state: VaultState = {
+      version: 1,
+      last_export: '',
+      docs: {
+        abc: { relPath: 'a.md', contentHash: 'h1' },
+        def: { relPath: 'b.md', contentHash: 'OLD' },
+      },
+    };
+    const plan = buildPlan(docs, state, {
+      onlyChanged: true,
+      createNew: false,
+      deleteMissing: false,
+      types: null,
+    });
+    expect(plan.summary.unchanged).toBe(1);
+    expect(plan.summary.changed).toBe(1);
+    expect(plan.summary.skippedNoId).toBe(1);
+    expect(plan.summary.created).toBe(0);
+  });
+
+  test('--create-new flips no-id into create', () => {
+    const docs = [mkDoc(undefined, 'h', 'x.md')];
+    const plan = buildPlan(docs, null, {
+      onlyChanged: true,
+      createNew: true,
+      deleteMissing: false,
+      types: null,
+    });
+    expect(plan.summary.created).toBe(1);
+    expect(plan.summary.skippedNoId).toBe(0);
+  });
+
+  test('--all overrides onlyChanged (pushes unchanged)', () => {
+    const docs = [mkDoc('abc', 'h1', 'a.md')];
+    const state: VaultState = {
+      version: 1,
+      last_export: '',
+      docs: { abc: { relPath: 'a.md', contentHash: 'h1' } },
+    };
+    const plan = buildPlan(docs, state, {
+      onlyChanged: false,
+      createNew: false,
+      deleteMissing: false,
+      types: null,
+    });
+    expect(plan.summary.changed).toBe(1);
+    expect(plan.summary.unchanged).toBe(0);
+  });
+
+  test('--delete-missing queues tombstones for state entries missing from vault', () => {
+    const docs = [mkDoc('abc', 'h1', 'a.md')];
+    const state: VaultState = {
+      version: 1,
+      last_export: '',
+      docs: {
+        abc: { relPath: 'a.md', contentHash: 'h1' },
+        gone: { relPath: 'gone.md', contentHash: 'zz' },
+      },
+    };
+    const plan = buildPlan(docs, state, {
+      onlyChanged: true,
+      createNew: false,
+      deleteMissing: true,
+      types: null,
+    });
+    expect(plan.summary.tombstoned).toBe(1);
+  });
+
+  test('types filter excludes non-matching docs', () => {
+    const docs = [
+      { ...mkDoc('abc', 'h', 'a.md'), meta: { arra_id: 'abc', arra_type: 'retro' } },
+      mkDoc('def', 'h2', 'b.md'),
+    ];
+    const plan = buildPlan(docs, null, {
+      onlyChanged: true,
+      createNew: false,
+      deleteMissing: false,
+      types: ['learning'],
+    });
+    expect(plan.items.length).toBe(1);
+    expect(plan.items[0]!.doc?.meta.arra_id).toBe('def');
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/index.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/index.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { parseArgs } from '../index.ts';
+
+describe('parseArgs', () => {
+  test('requires --in', () => {
+    expect(() => parseArgs([])).toThrow(/--in/);
+  });
+
+  test('defaults', () => {
+    const o = parseArgs(['--in', '/tmp/v']);
+    expect(o.in).toBe('/tmp/v');
+    expect(o.dryRun).toBe(false);
+    expect(o.onlyChanged).toBe(true);
+    expect(o.createNew).toBe(false);
+    expect(o.deleteMissing).toBe(false);
+    expect(o.verbose).toBe(false);
+    expect(o.types).toBeNull();
+  });
+
+  test('flags parse', () => {
+    const o = parseArgs([
+      '--in', '/tmp/v',
+      '--dry-run',
+      '--all',
+      '--create-new',
+      '--delete-missing',
+      '--verbose',
+      '--types', 'principle,learning',
+    ]);
+    expect(o.dryRun).toBe(true);
+    expect(o.onlyChanged).toBe(false);
+    expect(o.createNew).toBe(true);
+    expect(o.deleteMissing).toBe(true);
+    expect(o.verbose).toBe(true);
+    expect(o.types).toEqual(['principle', 'learning']);
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/parse-body.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/parse-body.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseVaultFile } from '../lib/parse-body.ts';
+import {
+  deriveTitle,
+  stripLeadingH1,
+  stripExportArtifacts,
+  extractTagsFromBody,
+  mergeConcepts,
+} from '../lib/parse-body.ts';
+
+let vault: string;
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), 'import-parse-test-'));
+});
+
+afterEach(async () => {
+  await rm(vault, { recursive: true, force: true });
+});
+
+describe('parse-body helpers', () => {
+  test('stripLeadingH1 removes first H1', () => {
+    expect(stripLeadingH1('# Hi\n\nbody')).toBe('body');
+    expect(stripLeadingH1('no h1')).toBe('no h1');
+  });
+
+  test('deriveTitle prefers H1 then meta then filename', () => {
+    expect(deriveTitle('# Found\n\nbody', {}, 'learnings/a.md')).toBe('Found');
+    expect(deriveTitle('body', { title: 'Meta' }, 'learnings/a.md')).toBe('Meta');
+    expect(deriveTitle('body', {}, 'learnings/my-file.md')).toBe('my-file');
+  });
+
+  test('extractTagsFromBody finds #tags outside code', () => {
+    const body = 'hello #foo and #bar-baz\n```\n#not-a-tag\n```\n';
+    expect(extractTagsFromBody(body).sort()).toEqual(['bar-baz', 'foo']);
+  });
+
+  test('stripExportArtifacts removes Related and Concepts sections', () => {
+    const body = [
+      '# Title',
+      '',
+      'real content',
+      '',
+      '## Related (by embedding)',
+      '- [[foo]] (0.90)',
+      '',
+      '## Concepts',
+      '#a #b',
+    ].join('\n');
+    const out = stripExportArtifacts(body);
+    expect(out).not.toContain('Related');
+    expect(out).not.toContain('## Concepts');
+    expect(out).toContain('real content');
+  });
+
+  test('mergeConcepts combines frontmatter + body tags, dedupes', () => {
+    const merged = mergeConcepts({ arra_concepts: ['foo', 'Bar'] }, 'hi #bar #baz');
+    expect(merged.sort()).toEqual(['bar', 'baz', 'foo']);
+  });
+});
+
+describe('parseVaultFile', () => {
+  test('parses a full file and produces a stable hash', async () => {
+    const path = join(vault, 'a.md');
+    await writeFile(
+      path,
+      [
+        '---',
+        'arra_id: doc_abc',
+        'arra_type: learning',
+        'arra_concepts: [foo, bar]',
+        '---',
+        '',
+        '# My Title',
+        '',
+        'some content #baz',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const doc = await parseVaultFile(path, 'a.md');
+    expect(doc.meta.arra_id).toBe('doc_abc');
+    expect(doc.title).toBe('My Title');
+    expect(doc.concepts.sort()).toEqual(['bar', 'baz', 'foo']);
+    expect(doc.body).toContain('some content');
+    expect(doc.contentHash).toBeTruthy();
+
+    // Same input → same hash.
+    const again = await parseVaultFile(path, 'a.md');
+    expect(again.contentHash).toBe(doc.contentHash);
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/parse-frontmatter.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/parse-frontmatter.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { parseFrontmatter } from '../lib/parse-frontmatter.ts';
+
+describe('parseFrontmatter', () => {
+  test('parses arra_id and scalar fields', () => {
+    const raw = `---\narra_id: abc123\narra_type: learning\n---\n# Title\n\nbody\n`;
+    const { meta, body } = parseFrontmatter(raw);
+    expect(meta.arra_id).toBe('abc123');
+    expect(meta.arra_type).toBe('learning');
+    expect(body.trim()).toBe('# Title\n\nbody'.trim());
+  });
+
+  test('parses inline arrays', () => {
+    const raw = `---\narra_concepts: [foo, bar, "baz qux"]\n---\nhi\n`;
+    const { meta } = parseFrontmatter(raw);
+    expect(meta.arra_concepts).toEqual(['foo', 'bar', 'baz qux']);
+  });
+
+  test('handles quoted strings with special chars', () => {
+    const raw = `---\ntitle: "hello: world"\n---\nbody\n`;
+    const { meta } = parseFrontmatter(raw);
+    expect(meta.title).toBe('hello: world');
+  });
+
+  test('returns empty meta when no frontmatter', () => {
+    const { meta, body } = parseFrontmatter('just text\n');
+    expect(meta).toEqual({});
+    expect(body).toBe('just text\n');
+  });
+
+  test('coerces numbers and booleans', () => {
+    const raw = `---\narra_similarity_threshold: 0.75\nenabled: true\nn: 5\n---\nbody\n`;
+    const { meta } = parseFrontmatter(raw);
+    expect(meta.arra_similarity_threshold).toBe(0.75);
+    expect(meta.enabled).toBe(true);
+    expect(meta.n).toBe(5);
+  });
+
+  test('empty array', () => {
+    const raw = `---\narra_concepts: []\n---\nhi\n`;
+    const { meta } = parseFrontmatter(raw);
+    expect(meta.arra_concepts).toEqual([]);
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/state-writer.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/state-writer.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeState, buildUpdatedState } from '../lib/state-writer.ts';
+import type { ImportDoc, VaultState } from '../lib/types.ts';
+
+let vault: string;
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), 'state-writer-test-'));
+});
+
+afterEach(async () => {
+  await rm(vault, { recursive: true, force: true });
+});
+
+function mkDoc(id: string, hash: string, rel = 'a.md'): ImportDoc {
+  return {
+    absPath: `/tmp/${rel}`,
+    relPath: rel,
+    meta: { arra_id: id },
+    body: 'x',
+    title: 'T',
+    concepts: [],
+    contentHash: hash,
+  };
+}
+
+describe('state-writer', () => {
+  test('writes state atomically', async () => {
+    const state: VaultState = {
+      version: 1,
+      last_export: '2026-04-19T00:00:00Z',
+      docs: { a: { relPath: 'a.md', contentHash: 'h1' } },
+    };
+    await writeState(vault, state);
+    const raw = await readFile(join(vault, '.arra-vault-state.json'), 'utf8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.docs.a.contentHash).toBe('h1');
+  });
+
+  test('buildUpdatedState merges prior state with new doc hashes', () => {
+    const prior: VaultState = {
+      version: 1,
+      last_export: '2026-01-01T00:00:00Z',
+      docs: {
+        keep: { relPath: 'keep.md', contentHash: 'kh' },
+        stale: { relPath: 'stale.md', contentHash: 'old' },
+      },
+    };
+    const next = buildUpdatedState(prior, [mkDoc('stale', 'new', 'stale.md'), mkDoc('fresh', 'fh', 'fresh.md')]);
+    expect(next.docs.keep?.contentHash).toBe('kh');
+    expect(next.docs.stale?.contentHash).toBe('new');
+    expect(next.docs.fresh?.contentHash).toBe('fh');
+  });
+
+  test('buildUpdatedState handles null prior state', () => {
+    const next = buildUpdatedState(null, [mkDoc('a', 'h', 'a.md')]);
+    expect(next.docs.a?.contentHash).toBe('h');
+    expect(next.version).toBe(1);
+  });
+});

--- a/cli/src/plugins/import-obsidian/__tests__/walk-vault.test.ts
+++ b/cli/src/plugins/import-obsidian/__tests__/walk-vault.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { walkVault } from '../lib/walk-vault.ts';
+
+let vault: string;
+
+beforeEach(async () => {
+  vault = await mkdtemp(join(tmpdir(), 'walk-vault-test-'));
+});
+
+afterEach(async () => {
+  await rm(vault, { recursive: true, force: true });
+});
+
+describe('walkVault', () => {
+  test('finds .md files, skips _index + _concepts + .obsidian + state file', async () => {
+    await mkdir(join(vault, 'learnings'), { recursive: true });
+    await mkdir(join(vault, '_concepts'), { recursive: true });
+    await mkdir(join(vault, '.obsidian'), { recursive: true });
+
+    await writeFile(join(vault, '_index.md'), '# index');
+    await writeFile(join(vault, '_concepts', 'hub.md'), '# hub');
+    await writeFile(join(vault, '.obsidian', 'config'), '{}');
+    await writeFile(join(vault, '.arra-vault-state.json'), '{}');
+    await writeFile(join(vault, 'learnings', 'a.md'), '# a');
+    await writeFile(join(vault, 'learnings', 'b.md'), '# b');
+    await writeFile(join(vault, 'learnings', 'notes.txt'), 'skip me');
+
+    const entries = await walkVault(vault);
+    const rels = entries.map((e) => e.relPath).sort();
+    expect(rels).toEqual(['learnings/a.md', 'learnings/b.md']);
+  });
+
+  test('returns empty on missing directory', async () => {
+    const out = await walkVault(join(vault, 'nope'));
+    expect(out).toEqual([]);
+  });
+});

--- a/cli/src/plugins/import-obsidian/index.ts
+++ b/cli/src/plugins/import-obsidian/index.ts
@@ -1,0 +1,108 @@
+// arra-cli import-obsidian --in <path> [flags]
+// Issue #938 — round-trip: pull edited vault files back into ARRA.
+
+import type { InvokeContext, InvokeResult } from '../../plugin/types.ts';
+import type { ImportDoc, ImportOptions } from './lib/types.ts';
+import { walkVault } from './lib/walk-vault.ts';
+import { parseVaultFile } from './lib/parse-body.ts';
+import { loadState, buildPlan } from './lib/diff-state.ts';
+import { applyPlan } from './lib/apply-changes.ts';
+import { buildUpdatedState, writeState } from './lib/state-writer.ts';
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  let opts: ImportOptions;
+  try {
+    opts = parseArgs(ctx.args);
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+
+  const lines: string[] = [];
+  const log = (s: string) => lines.push(s);
+
+  log(`Obsidian vault import ← ${opts.in}`);
+
+  const entries = await walkVault(opts.in);
+  const docs: ImportDoc[] = [];
+  for (const entry of entries) {
+    try {
+      docs.push(await parseVaultFile(entry.absPath, entry.relPath));
+    } catch (err) {
+      log(`  WARN parse: ${entry.relPath} — ${errMsg(err)}`);
+    }
+  }
+
+  const state = await loadState(opts.in);
+  const plan = buildPlan(docs, state, {
+    onlyChanged: opts.onlyChanged,
+    createNew: opts.createNew,
+    deleteMissing: opts.deleteMissing,
+    types: opts.types,
+  });
+
+  log(`  scanned:    ${docs.length}`);
+  log(`  changed:    ${plan.summary.changed}`);
+  log(`  create:     ${plan.summary.created}`);
+  log(`  unchanged:  ${plan.summary.unchanged}`);
+  log(`  skip-no-id: ${plan.summary.skippedNoId}`);
+  if (plan.summary.tombstoned > 0) log(`  tombstone:  ${plan.summary.tombstoned}`);
+  if (opts.dryRun) log(`  (dry-run — no writes)`);
+
+  const result = await applyPlan(plan, { dryRun: opts.dryRun, verbose: opts.verbose, log });
+
+  log(`  applied:    ${result.applied}`);
+  if (result.created > 0) log(`  created:    ${result.created}`);
+  if (result.skipped > 0) log(`  skipped:    ${result.skipped}`);
+  if (result.failed > 0) log(`  failed:     ${result.failed}`);
+
+  if (!opts.dryRun && result.failed === 0) {
+    const touched = plan.items
+      .filter((i) => (i.action === 'update' || i.action === 'create') && i.doc)
+      .map((i) => i.doc!) as ImportDoc[];
+    const next = buildUpdatedState(state, touched, { model: state?.model, threshold: state?.threshold });
+    try {
+      await writeState(opts.in, next);
+      log(`  state:      .arra-vault-state.json updated`);
+    } catch (err) {
+      log(`  WARN state-write: ${errMsg(err)}`);
+    }
+  }
+
+  const ok = result.failed === 0;
+  return ok ? { ok, output: lines.join('\n') } : { ok, error: lines.join('\n') };
+}
+
+export function parseArgs(args: string[]): ImportOptions {
+  const opts: ImportOptions = {
+    in: '',
+    dryRun: false,
+    onlyChanged: true,
+    types: null,
+    createNew: false,
+    deleteMissing: false,
+    verbose: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    const next = () => args[++i];
+    if (a === '--in') opts.in = next() ?? '';
+    else if (a === '--dry-run') opts.dryRun = true;
+    else if (a === '--only-changed') opts.onlyChanged = true;
+    else if (a === '--all') opts.onlyChanged = false;
+    else if (a === '--types') {
+      opts.types = (next() ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (a === '--create-new') opts.createNew = true;
+    else if (a === '--delete-missing') opts.deleteMissing = true;
+    else if (a === '--verbose') opts.verbose = true;
+  }
+
+  if (!opts.in) {
+    throw new Error('Usage: arra-cli import-obsidian --in <path> [flags]');
+  }
+  return opts;
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/cli/src/plugins/import-obsidian/lib/apply-changes.ts
+++ b/cli/src/plugins/import-obsidian/lib/apply-changes.ts
@@ -1,0 +1,113 @@
+// Apply an ImportPlan against the ARRA Oracle HTTP API.
+// - 'update' → PATCH /api/doc/:id with { content, concepts, title }
+// - 'create' → POST /api/doc with full doc (skipped unless --create-new)
+// - 'skip-unchanged' / 'skip-no-id' → no-op
+// - 'tombstone' → POST /api/supersede (if endpoint present) OR warn + skip
+//   (for Phase 1 we warn + skip tombstones; --delete-missing default is OFF)
+
+import { apiFetch } from '../../../lib/api.ts';
+import type { ImportDoc, ImportPlan, ImportResult, ImportPlanItem } from './types.ts';
+
+export interface ApplyOptions {
+  dryRun: boolean;
+  verbose: boolean;
+  log: (line: string) => void;
+}
+
+export async function applyPlan(plan: ImportPlan, opts: ApplyOptions): Promise<ImportResult> {
+  const result: ImportResult = { applied: 0, created: 0, failed: 0, skipped: 0, errors: [] };
+
+  for (const item of plan.items) {
+    try {
+      if (item.action === 'skip-unchanged') {
+        result.skipped++;
+        if (opts.verbose && item.doc) opts.log(`  unchanged: ${item.doc.relPath}`);
+        continue;
+      }
+      if (item.action === 'skip-no-id') {
+        result.skipped++;
+        const rel = item.doc?.relPath ?? '?';
+        opts.log(`  WARN skip (no arra_id): ${rel} — rerun with --create-new to create`);
+        continue;
+      }
+      if (item.action === 'tombstone') {
+        result.skipped++;
+        opts.log(`  WARN tombstone not applied (Phase 2): ${item.relPath ?? item.arraId}`);
+        continue;
+      }
+
+      if (opts.dryRun) {
+        const rel = item.doc?.relPath ?? '?';
+        opts.log(`  [dry-run] ${item.action}: ${rel}`);
+        if (item.action === 'update') result.applied++;
+        else if (item.action === 'create') result.created++;
+        continue;
+      }
+
+      if (item.action === 'update' && item.doc) {
+        await patchDoc(item.doc);
+        result.applied++;
+        if (opts.verbose) opts.log(`  updated: ${item.doc.relPath}`);
+      } else if (item.action === 'create' && item.doc) {
+        const id = await createDoc(item.doc);
+        result.created++;
+        if (opts.verbose) opts.log(`  created: ${item.doc.relPath} → ${id}`);
+        // Stash the returned id on the doc so state-writer can record it.
+        item.doc.meta.arra_id = id;
+      }
+    } catch (err) {
+      result.failed++;
+      const rel = item.doc?.relPath ?? item.relPath ?? '?';
+      const msg = err instanceof Error ? err.message : String(err);
+      result.errors.push({ relPath: rel, message: msg });
+      opts.log(`  ERROR ${item.action}: ${rel} — ${msg}`);
+    }
+  }
+  return result;
+}
+
+async function patchDoc(doc: ImportDoc): Promise<void> {
+  const id = doc.meta.arra_id as string;
+  const body = {
+    content: composeContent(doc),
+    concepts: doc.concepts,
+    title: doc.title,
+  };
+  const res = await apiFetch(`/api/doc/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`PATCH /api/doc/${id} → HTTP ${res.status} ${text.slice(0, 200)}`);
+  }
+}
+
+async function createDoc(doc: ImportDoc): Promise<string> {
+  const body = {
+    type: (doc.meta.arra_type as string | undefined) ?? 'learning',
+    content: composeContent(doc),
+    concepts: doc.concepts,
+    source_file: `imported/${doc.relPath}`,
+    project: doc.meta.arra_project as string | undefined,
+  };
+  const res = await apiFetch(`/api/doc`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`POST /api/doc → HTTP ${res.status} ${text.slice(0, 200)}`);
+  }
+  const json = (await res.json()) as { id?: string };
+  if (!json.id) throw new Error(`POST /api/doc returned no id`);
+  return json.id;
+}
+
+/** Title + body, normalised, with no double H1. */
+export function composeContent(doc: ImportDoc): string {
+  const body = doc.body.trim();
+  return body ? `# ${doc.title}\n\n${body}\n` : `# ${doc.title}\n`;
+}

--- a/cli/src/plugins/import-obsidian/lib/diff-state.ts
+++ b/cli/src/plugins/import-obsidian/lib/diff-state.ts
@@ -1,0 +1,76 @@
+// Load .arra-vault-state.json and classify each parsed vault doc as
+// update / create / skip-unchanged / skip-no-id / tombstone.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ImportDoc, ImportPlan, ImportPlanItem, VaultState } from './types.ts';
+
+const STATE_FILE = '.arra-vault-state.json';
+
+export async function loadState(vaultDir: string): Promise<VaultState | null> {
+  try {
+    const raw = await readFile(join(vaultDir, STATE_FILE), 'utf8');
+    const parsed = JSON.parse(raw) as VaultState;
+    if (!parsed || typeof parsed !== 'object' || !parsed.docs) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export interface DiffOptions {
+  onlyChanged: boolean;
+  createNew: boolean;
+  deleteMissing: boolean;
+  types: string[] | null;
+}
+
+export function buildPlan(
+  docs: ImportDoc[],
+  state: VaultState | null,
+  opts: DiffOptions,
+): ImportPlan {
+  const items: ImportPlanItem[] = [];
+  const summary = { changed: 0, created: 0, unchanged: 0, skippedNoId: 0, tombstoned: 0 };
+
+  const seenIds = new Set<string>();
+
+  for (const doc of docs) {
+    if (opts.types && opts.types.length > 0) {
+      const t = (doc.meta.arra_type as string | undefined) ?? '';
+      if (!opts.types.includes(t)) continue;
+    }
+    const id = typeof doc.meta.arra_id === 'string' ? doc.meta.arra_id : undefined;
+
+    if (!id) {
+      if (opts.createNew) {
+        items.push({ doc, action: 'create', reason: 'no arra_id → --create-new' });
+        summary.created++;
+      } else {
+        items.push({ doc, action: 'skip-no-id', reason: 'no arra_id — pass --create-new to create' });
+        summary.skippedNoId++;
+      }
+      continue;
+    }
+
+    seenIds.add(id);
+    const prev = state?.docs[id];
+    if (opts.onlyChanged && prev && prev.contentHash === doc.contentHash) {
+      items.push({ doc, action: 'skip-unchanged' });
+      summary.unchanged++;
+      continue;
+    }
+    items.push({ doc, action: 'update' });
+    summary.changed++;
+  }
+
+  if (opts.deleteMissing && state) {
+    for (const [id, entry] of Object.entries(state.docs)) {
+      if (seenIds.has(id)) continue;
+      items.push({ arraId: id, relPath: entry.relPath, action: 'tombstone' });
+      summary.tombstoned++;
+    }
+  }
+
+  return { items, summary };
+}

--- a/cli/src/plugins/import-obsidian/lib/parse-body.ts
+++ b/cli/src/plugins/import-obsidian/lib/parse-body.ts
@@ -1,0 +1,80 @@
+// Parse a single Obsidian .md file into an ImportDoc.
+// - Reads from disk
+// - Strips frontmatter + leading H1 + trailing export-generated sections
+// - Extracts concepts from frontmatter + inline #tag lines
+// - Computes a content hash over the payload we'll send to ARRA.
+
+import { readFile } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { parseFrontmatter } from './parse-frontmatter.ts';
+import type { ImportDoc, DocMeta } from './types.ts';
+
+export async function parseVaultFile(absPath: string, relPath: string): Promise<ImportDoc> {
+  const raw = await readFile(absPath, 'utf8');
+  const { meta, body } = parseFrontmatter(raw);
+
+  const title = deriveTitle(body, meta, relPath);
+  const cleanedBody = stripExportArtifacts(stripLeadingH1(body)).trim();
+  const concepts = mergeConcepts(meta, cleanedBody);
+  const contentHash = hashPayload(title, cleanedBody, concepts);
+
+  return {
+    absPath,
+    relPath,
+    meta,
+    body: cleanedBody,
+    title,
+    concepts,
+    contentHash,
+  };
+}
+
+export function deriveTitle(body: string, meta: DocMeta, relPath: string): string {
+  const h1 = body.match(/^\s*#\s+(.+?)\s*$/m);
+  if (h1 && h1[1].trim()) return h1[1].trim();
+  if (typeof meta['title'] === 'string' && (meta['title'] as string).trim()) {
+    return (meta['title'] as string).trim();
+  }
+  const name = basename(relPath).replace(/\.(md|markdown)$/i, '');
+  return name || '(untitled)';
+}
+
+export function stripLeadingH1(body: string): string {
+  return body.replace(/^\s*#\s+.+?\s*(?:\r?\n|$)/, '');
+}
+
+/** Remove sections the export plugin appends so re-importing doesn't duplicate them. */
+export function stripExportArtifacts(body: string): string {
+  // Strip "## Related (by embedding)" block until next ## or EOF.
+  let out = body.replace(/\n##\s+Related \(by embedding\)[\s\S]*?(?=\n##\s|\s*$)/i, '\n');
+  // Strip "## Concepts\n#tag #tag" block at the end.
+  out = out.replace(/\n##\s+Concepts\b[\s\S]*?(?=\n##\s|\s*$)/i, '\n');
+  return out;
+}
+
+export function extractTagsFromBody(body: string): string[] {
+  const tags: string[] = [];
+  // #tag patterns: word chars including _ and -, not inside code fences.
+  // Simple heuristic — strip fenced code blocks first.
+  const noCode = body.replace(/```[\s\S]*?```/g, '').replace(/`[^`]*`/g, '');
+  const re = /(?:^|\s)#([a-z0-9][a-z0-9_\-/]*)/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(noCode)) !== null) {
+    tags.push(m[1].toLowerCase());
+  }
+  return tags;
+}
+
+export function mergeConcepts(meta: DocMeta, body: string): string[] {
+  const fromMeta = Array.isArray(meta.arra_concepts) ? meta.arra_concepts : [];
+  const fromBody = extractTagsFromBody(body);
+  const merged = [...fromMeta, ...fromBody]
+    .filter((c): c is string => typeof c === 'string' && c.length > 0)
+    .map((c) => c.toLowerCase());
+  return Array.from(new Set(merged));
+}
+
+export function hashPayload(title: string, body: string, concepts: string[]): string {
+  const payload = `${title}\n---\n${body}\n---\n${concepts.slice().sort().join(',')}`;
+  return Bun.hash(payload).toString(16);
+}

--- a/cli/src/plugins/import-obsidian/lib/parse-frontmatter.ts
+++ b/cli/src/plugins/import-obsidian/lib/parse-frontmatter.ts
@@ -1,0 +1,88 @@
+// Minimal YAML frontmatter parser — just enough to read the arra_* keys
+// the export plugin writes. Supports: scalars (quoted + bare), inline arrays
+// [a, b, "c"], and numbers/booleans. Pure, no I/O.
+
+import type { DocMeta } from './types.ts';
+
+export interface ParsedFile {
+  meta: DocMeta;
+  body: string;
+}
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export function parseFrontmatter(raw: string): ParsedFile {
+  const m = FRONTMATTER_RE.exec(raw);
+  if (!m) return { meta: {}, body: raw };
+  const yamlBlock = m[1];
+  const body = m[2] ?? '';
+  const meta = parseYaml(yamlBlock);
+  return { meta, body };
+}
+
+function parseYaml(block: string): DocMeta {
+  const out: DocMeta = {};
+  const lines = block.split(/\r?\n/);
+  for (const rawLine of lines) {
+    const line = rawLine.replace(/^\s+|\s+$/g, '');
+    if (!line || line.startsWith('#')) continue;
+    const colon = line.indexOf(':');
+    if (colon < 0) continue;
+    const key = line.slice(0, colon).trim();
+    const value = line.slice(colon + 1).trim();
+    if (!key) continue;
+    out[key] = coerceScalar(value);
+  }
+  return out;
+}
+
+function coerceScalar(v: string): unknown {
+  if (v === '') return '';
+  if (v === 'null' || v === '~') return null;
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  if (/^-?\d+$/.test(v)) return parseInt(v, 10);
+  if (/^-?\d+\.\d+$/.test(v)) return parseFloat(v);
+  if (v.startsWith('[') && v.endsWith(']')) return parseInlineArray(v.slice(1, -1));
+  if ((v.startsWith('"') && v.endsWith('"')) || (v.startsWith("'") && v.endsWith("'"))) {
+    return unquote(v);
+  }
+  return v;
+}
+
+function unquote(v: string): string {
+  const q = v[0];
+  const inner = v.slice(1, -1);
+  if (q === '"') return inner.replace(/\\"/g, '"').replace(/\\\\/g, '\\').replace(/\\n/g, '\n');
+  return inner.replace(/''/g, "'");
+}
+
+function parseInlineArray(inner: string): string[] {
+  if (!inner.trim()) return [];
+  const out: string[] = [];
+  let cur = '';
+  let quote: '"' | "'" | null = null;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (quote) {
+      if (c === quote && inner[i - 1] !== '\\') {
+        quote = null;
+        continue;
+      }
+      cur += c;
+      continue;
+    }
+    if (c === '"' || c === "'") {
+      quote = c;
+      continue;
+    }
+    if (c === ',') {
+      out.push(cur.trim());
+      cur = '';
+      continue;
+    }
+    cur += c;
+  }
+  if (cur.trim()) out.push(cur.trim());
+  return out.map((s) => s.replace(/^['"]|['"]$/g, ''));
+}

--- a/cli/src/plugins/import-obsidian/lib/state-writer.ts
+++ b/cli/src/plugins/import-obsidian/lib/state-writer.ts
@@ -1,0 +1,39 @@
+// Write .arra-vault-state.json atomically (temp + rename).
+// Only called on successful non-dry-run imports / exports.
+
+import { mkdir, rename } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import type { ImportDoc, VaultState } from './types.ts';
+
+const STATE_FILE = '.arra-vault-state.json';
+
+export async function writeState(vaultDir: string, state: VaultState): Promise<void> {
+  const abs = join(vaultDir, STATE_FILE);
+  await mkdir(dirname(abs), { recursive: true });
+  const tmp = `${abs}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  await Bun.write(tmp, JSON.stringify(state, null, 2) + '\n');
+  await rename(tmp, abs);
+}
+
+/** Merge a prior state with the docs we just imported; any doc that now has
+ * an arra_id + contentHash gets its entry refreshed. Missing docs are left
+ * alone unless removeIds is provided. */
+export function buildUpdatedState(
+  prior: VaultState | null,
+  docs: ImportDoc[],
+  defaults: { model?: string; threshold?: number } = {},
+): VaultState {
+  const next: VaultState = {
+    version: 1,
+    last_export: new Date().toISOString(),
+    model: defaults.model ?? prior?.model,
+    threshold: defaults.threshold ?? prior?.threshold,
+    docs: { ...(prior?.docs ?? {}) },
+  };
+  for (const d of docs) {
+    const id = typeof d.meta.arra_id === 'string' ? d.meta.arra_id : undefined;
+    if (!id) continue;
+    next.docs[id] = { relPath: d.relPath, contentHash: d.contentHash };
+  }
+  return next;
+}

--- a/cli/src/plugins/import-obsidian/lib/types.ts
+++ b/cli/src/plugins/import-obsidian/lib/types.ts
@@ -1,0 +1,87 @@
+// Shared types for the import-obsidian plugin (issue #938).
+// Round-trip: Obsidian vault → ARRA docs.
+
+/** Parsed frontmatter from an Obsidian .md file. */
+export interface DocMeta {
+  arra_id?: string;
+  arra_type?: string;
+  arra_project?: string;
+  arra_created?: string;
+  arra_concepts?: string[];
+  [key: string]: unknown;
+}
+
+/** A parsed Obsidian doc ready for diff + apply. */
+export interface ImportDoc {
+  /** Absolute path on disk. */
+  absPath: string;
+  /** Path relative to vault root, forward-slash. */
+  relPath: string;
+  /** Parsed frontmatter (arra_id etc.). */
+  meta: DocMeta;
+  /** Body without frontmatter and leading H1. */
+  body: string;
+  /** Title — from H1 if present, else filename base. */
+  title: string;
+  /** Concepts merged from frontmatter + #tag lines in body, lowercased + deduped. */
+  concepts: string[];
+  /** Hash of (title + body + concepts) — the payload we send to ARRA. */
+  contentHash: string;
+}
+
+/** Entry in .arra-vault-state.json. */
+export interface StateEntry {
+  relPath: string;
+  contentHash: string;
+}
+
+/** Vault state file written at export time, read at import time. */
+export interface VaultState {
+  version: number;
+  last_export: string;
+  model?: string;
+  threshold?: number;
+  docs: Record<string, StateEntry>;
+}
+
+/** Classification of a single doc vs. the state file. */
+export type ImportAction = 'update' | 'create' | 'skip-unchanged' | 'skip-no-id' | 'tombstone';
+
+export interface ImportPlanItem {
+  doc?: ImportDoc;
+  /** For tombstone entries (doc was in state, missing from vault). */
+  arraId?: string;
+  /** For tombstone entries. */
+  relPath?: string;
+  action: ImportAction;
+  reason?: string;
+}
+
+export interface ImportPlan {
+  items: ImportPlanItem[];
+  summary: {
+    changed: number;
+    created: number;
+    unchanged: number;
+    skippedNoId: number;
+    tombstoned: number;
+  };
+}
+
+export interface ImportResult {
+  applied: number;
+  created: number;
+  failed: number;
+  skipped: number;
+  errors: Array<{ relPath: string; message: string }>;
+}
+
+export interface ImportOptions {
+  in: string;
+  dryRun: boolean;
+  onlyChanged: boolean;
+  types: string[] | null;
+  createNew: boolean;
+  deleteMissing: boolean;
+  verbose: boolean;
+}

--- a/cli/src/plugins/import-obsidian/lib/walk-vault.ts
+++ b/cli/src/plugins/import-obsidian/lib/walk-vault.ts
@@ -1,0 +1,53 @@
+// Walk an Obsidian vault and yield .md file paths.
+// Skips: _index.md, _concepts/** (those are export-generated hubs, not user content),
+// and anything under .obsidian/ or node_modules/ or dot-directories.
+
+import { readdir, stat } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+
+const SKIP_DIRS = new Set(['.obsidian', 'node_modules', '.git', '_concepts']);
+const SKIP_FILES = new Set(['_index.md', '.arra-vault-state.json']);
+
+export interface WalkEntry {
+  absPath: string;
+  relPath: string; // forward-slash
+}
+
+export async function walkVault(vaultDir: string): Promise<WalkEntry[]> {
+  const out: WalkEntry[] = [];
+  await walk(vaultDir, vaultDir, out);
+  return out;
+}
+
+async function walk(root: string, dir: string, out: WalkEntry[]): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+
+  for (const name of entries) {
+    if (name.startsWith('.') && name !== '.arra-vault-state.json') continue;
+    if (SKIP_DIRS.has(name)) continue;
+
+    const abs = join(dir, name);
+    let info;
+    try {
+      info = await stat(abs);
+    } catch {
+      continue;
+    }
+
+    if (info.isDirectory()) {
+      await walk(root, abs, out);
+      continue;
+    }
+    if (!info.isFile()) continue;
+    if (!name.endsWith('.md')) continue;
+    if (SKIP_FILES.has(name)) continue;
+
+    const rel = relative(root, abs).split(sep).join('/');
+    out.push({ absPath: abs, relPath: rel });
+  }
+}

--- a/cli/src/plugins/import-obsidian/plugin.json
+++ b/cli/src/plugins/import-obsidian/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "arra-import-obsidian",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^0.0.1",
+  "weight": 21,
+  "description": "Import edits from an Obsidian vault back into ARRA Oracle (round-trip — closes #938)",
+  "cli": {
+    "command": "import-obsidian",
+    "help": "arra-cli import-obsidian --in <path> [--dry-run] [--only-changed|--all] [--types principle,learning,retro] [--create-new] [--delete-missing] [--verbose]",
+    "flags": {
+      "--in": "Vault directory (required)",
+      "--dry-run": "Report planned changes, write nothing",
+      "--only-changed": "Skip files whose content hash matches last-export state (default: on)",
+      "--all": "Override --only-changed, re-push every file",
+      "--types": "Comma-separated doc types to include",
+      "--create-new": "Create docs that have no arra_id (default: skip + warn)",
+      "--delete-missing": "Tombstone docs in state but missing from vault (default: off)",
+      "--verbose": "Print per-file decisions"
+    }
+  }
+}

--- a/src/routes/files/doc.ts
+++ b/src/routes/files/doc.ts
@@ -1,46 +1,166 @@
-import { Elysia } from 'elysia';
-import { sqlite } from '../../db/index.ts';
+import { Elysia, t } from 'elysia';
+import { sqlite, db, oracleDocuments } from '../../db/index.ts';
+import { eq } from 'drizzle-orm';
 import { docParams } from './model.ts';
 
-export const docRoute = new Elysia().get(
-  '/api/doc/:id',
-  ({ params, set }) => {
-    try {
-      const row = sqlite
-        .prepare(
-          `
+// Body schemas for PATCH/POST.
+const PatchDocBody = t.Object({
+  content: t.Optional(t.String()),
+  concepts: t.Optional(t.Array(t.String())),
+  title: t.Optional(t.String()),
+});
+
+const PostDocBody = t.Object({
+  id: t.Optional(t.String()),
+  type: t.String(),
+  content: t.String(),
+  concepts: t.Optional(t.Array(t.String())),
+  source_file: t.Optional(t.String()),
+  project: t.Optional(t.String()),
+});
+
+export const docRoute = new Elysia()
+  .get(
+    '/api/doc/:id',
+    ({ params, set }) => {
+      try {
+        const row = sqlite
+          .prepare(
+            `
         SELECT d.id, d.type, d.source_file, d.concepts, d.project, f.content
         FROM oracle_documents d
         JOIN oracle_fts f ON d.id = f.id
         WHERE d.id = ?
       `,
-        )
-        .get(params.id) as any;
+          )
+          .get(params.id) as any;
 
-      if (!row) {
-        set.status = 404;
-        return { error: 'Document not found' };
+        if (!row) {
+          set.status = 404;
+          return { error: 'Document not found' };
+        }
+
+        return {
+          id: row.id,
+          type: row.type,
+          content: row.content,
+          source_file: row.source_file,
+          concepts: JSON.parse(row.concepts || '[]'),
+          project: row.project,
+        };
+      } catch (e: any) {
+        set.status = 500;
+        return { error: e.message };
       }
-
-      return {
-        id: row.id,
-        type: row.type,
-        content: row.content,
-        source_file: row.source_file,
-        concepts: JSON.parse(row.concepts || '[]'),
-        project: row.project,
-      };
-    } catch (e: any) {
-      set.status = 500;
-      return { error: e.message };
-    }
-  },
-  {
-    params: docParams,
-    detail: {
-      tags: ['files'],
-      menu: { group: 'hidden' },
-      summary: 'Get one oracle document by id',
     },
-  },
-);
+    {
+      params: docParams,
+      detail: {
+        tags: ['files'],
+        menu: { group: 'hidden' },
+        summary: 'Get one oracle document by id',
+      },
+    },
+  )
+  .patch(
+    '/api/doc/:id',
+    ({ params, body, set }) => {
+      try {
+        const existing = sqlite
+          .prepare(`SELECT id FROM oracle_documents WHERE id = ?`)
+          .get(params.id) as { id: string } | undefined;
+        if (!existing) {
+          set.status = 404;
+          return { error: 'Document not found' };
+        }
+
+        const data = (body ?? {}) as Record<string, any>;
+        const now = Date.now();
+
+        const patch: Record<string, any> = { updatedAt: now, indexedAt: now };
+        if (Array.isArray(data.concepts)) {
+          const dedup = Array.from(
+            new Set(data.concepts.filter((c: any) => typeof c === 'string' && c).map((c: string) => c.toLowerCase())),
+          );
+          patch.concepts = JSON.stringify(dedup);
+        }
+
+        db.update(oracleDocuments).set(patch).where(eq(oracleDocuments.id, params.id)).run();
+
+        if (typeof data.content === 'string') {
+          const conceptsRow = sqlite.prepare(`SELECT concepts FROM oracle_documents WHERE id = ?`).get(params.id) as { concepts: string };
+          const conceptsArr: string[] = conceptsRow ? JSON.parse(conceptsRow.concepts || '[]') : [];
+          sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(params.id);
+          sqlite
+            .prepare(`INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)`)
+            .run(params.id, data.content, conceptsArr.join(' '));
+        }
+
+        return { ok: true, id: params.id };
+      } catch (e: any) {
+        set.status = 500;
+        return { error: e.message };
+      }
+    },
+    {
+      params: docParams,
+      body: PatchDocBody,
+      detail: {
+        tags: ['files'],
+        menu: { group: 'hidden' },
+        summary: 'Update a doc (content/concepts) — for Obsidian round-trip',
+      },
+    },
+  )
+  .post(
+    '/api/doc',
+    ({ body, set }) => {
+      try {
+        const data = (body ?? {}) as Record<string, any>;
+        const now = Date.now();
+        const id = typeof data.id === 'string' && data.id
+          ? data.id
+          : `${data.type}_${now}_${Math.random().toString(36).slice(2, 8)}`;
+
+        const existing = sqlite.prepare(`SELECT id FROM oracle_documents WHERE id = ?`).get(id);
+        if (existing) {
+          set.status = 409;
+          return { error: `Document already exists: ${id}` };
+        }
+
+        const conceptsArr: string[] = Array.isArray(data.concepts)
+          ? Array.from(new Set(data.concepts.filter((c: any) => typeof c === 'string' && c).map((c: string) => c.toLowerCase())))
+          : [];
+
+        db.insert(oracleDocuments).values({
+          id,
+          type: data.type,
+          sourceFile: data.source_file ?? `imported/${id}.md`,
+          concepts: JSON.stringify(conceptsArr),
+          createdAt: now,
+          updatedAt: now,
+          indexedAt: now,
+          project: typeof data.project === 'string' ? data.project.toLowerCase() : null,
+          createdBy: 'import-obsidian',
+        }).run();
+
+        sqlite.prepare(`DELETE FROM oracle_fts WHERE id = ?`).run(id);
+        sqlite
+          .prepare(`INSERT INTO oracle_fts (id, content, concepts) VALUES (?, ?, ?)`)
+          .run(id, data.content, conceptsArr.join(' '));
+
+        return { ok: true, id };
+      } catch (e: any) {
+        set.status = 500;
+        return { error: e.message };
+      }
+    },
+    {
+      body: PostDocBody,
+      detail: {
+        tags: ['files'],
+        menu: { group: 'hidden' },
+        summary: 'Create a new doc — for Obsidian round-trip --create-new',
+      },
+    },
+  );


### PR DESCRIPTION
## Summary

Closes #938 — closes the Obsidian round-trip loop. Now the full flow works:
1. `arra-cli export-obsidian --out ~/vault` (shipped in #933)
2. Edit docs in Obsidian (graph view, wikilinks, tags)
3. `arra-cli import-obsidian --in ~/vault` — pulls edits back into ARRA, preserves ids, updates concepts from `#tags`

### CLI

New plugin `cli/src/plugins/import-obsidian/`:
- `walk-vault.ts` — list .md files, skip `_index.md`, `_concepts/**`, dotfiles
- `parse-frontmatter.ts` — minimal YAML parser for `arra_*` keys
- `parse-body.ts` — strip frontmatter + leading H1, extract `#tag` concepts, compute content hash
- `diff-state.ts` — load `.arra-vault-state.json` and classify each file as update / create / skip-unchanged / skip-no-id / tombstone
- `apply-changes.ts` — PATCH `/api/doc/:id` or POST `/api/doc`
- `state-writer.ts` — atomic write (temp + rename) of updated state

Flags: `--in`, `--dry-run`, `--only-changed` (default on), `--all`, `--types`, `--create-new` (default **off**, warns + skips no-id), `--delete-missing` (default **off**, Phase 2), `--verbose`.

### Export plugin touch-up

`export-obsidian` now writes `.arra-vault-state.json` at the vault root with `{ version, last_export, model, threshold, docs: { id: { relPath, contentHash } } }` — enables `--only-changed` diffing on import. Uses the same `hashPayload` helper as import-obsidian so hashes match.

### Backend

`src/routes/files/doc.ts`:
- Added `PATCH /api/doc/:id` — accepts `{ content?, concepts?, title? }`, updates `oracle_documents` row + rewrites the `oracle_fts` entry.
- Added `POST /api/doc` — creates a new doc with `createdBy: 'import-obsidian'`.

Vector reindex happens on the next full `bun run index` pass (same as `arra_learn`).

### Safety

- `--create-new` defaults **off**; no-id docs warn + skip (won't create duplicates if a user accidentally deletes `arra_id:` frontmatter).
- `--delete-missing` defaults **off**; Phase 2 will wire this up to supersede.
- Dry-run writes nothing, including the state file.
- All state writes are atomic (temp + rename).

### LOC per new/modified file (all ≤200)
- `cli/src/plugins/import-obsidian/index.ts` 108
- `cli/src/plugins/import-obsidian/lib/apply-changes.ts` 113
- `cli/src/plugins/import-obsidian/lib/diff-state.ts` 76
- `cli/src/plugins/import-obsidian/lib/parse-body.ts` 80
- `cli/src/plugins/import-obsidian/lib/parse-frontmatter.ts` 88
- `cli/src/plugins/import-obsidian/lib/state-writer.ts` 39
- `cli/src/plugins/import-obsidian/lib/types.ts` 87
- `cli/src/plugins/import-obsidian/lib/walk-vault.ts` 53
- `cli/src/plugins/export-obsidian/lib/state-hash.ts` 16
- `src/routes/files/doc.ts` 166
- Tests: 7 files, 531 lines total, 34 tests

## Test plan

- [x] `bun test cli/src/plugins/import-obsidian` — 34 pass, 0 fail
- [x] `bun test` in cli — all 100 tests pass (34 new + 66 existing)
- [x] `bunx tsc --noEmit --allowImportingTsExtensions` — clean for new files
- [ ] Manual round-trip: `export-obsidian --out /tmp/v` → edit a file → `import-obsidian --in /tmp/v --dry-run` shows the change → apply → re-run, sees nothing changed
- [ ] `--create-new` manual test — remove `arra_id`, confirm warn+skip default, confirm create with flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)