### PR TITLE
fix(export-obsidian): resolve slug collisions (closes #942)

### DIFF
--- a/cli/src/plugins/export-obsidian/__tests__/slugify.test.ts
+++ b/cli/src/plugins/export-obsidian/__tests__/slugify.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { slugify, slugifyPath } from "../lib/slugify.ts";
+import { slugify, slugifyPath, shortIdHash } from "../lib/slugify.ts";
 
 describe("slugify", () => {
   test("lowercases ASCII", () => {
@@ -82,5 +82,26 @@ describe("slugifyPath", () => {
     expect(slugifyPath("learning", "0197abc-def", "")).toBe(
       "learnings/0197abc-def.md",
     );
+  });
+});
+
+describe("shortIdHash", () => {
+  test("deterministic — same id produces same hash", () => {
+    expect(shortIdHash("abc-123")).toBe(shortIdHash("abc-123"));
+  });
+
+  test("distinct ids produce distinct hashes (high probability)", () => {
+    expect(shortIdHash("retro_2026-04-19_a")).not.toBe(
+      shortIdHash("retro_2026-04-19_b"),
+    );
+  });
+
+  test("length default 8, custom length respected", () => {
+    expect(shortIdHash("abc").length).toBe(8);
+    expect(shortIdHash("abc", 4).length).toBe(4);
+  });
+
+  test("returns only [0-9a-z]", () => {
+    expect(shortIdHash("anything")).toMatch(/^[0-9a-z]+$/);
   });
 });

--- a/cli/src/plugins/export-obsidian/index.ts
+++ b/cli/src/plugins/export-obsidian/index.ts
@@ -16,7 +16,7 @@ import type {
   VaultFile,
   VaultStats,
 } from "./lib/types.ts";
-import { slugify, slugifyPath } from "./lib/slugify.ts";
+import { slugify, slugifyPath, shortIdHash } from "./lib/slugify.ts";
 import { writeVault, writeStateFile } from "./lib/vault-writer.ts";
 import { fetchAllDocs } from "./lib/fetch-docs.ts";
 import { fetchSimilar } from "./lib/fetch-similar.ts";
@@ -40,11 +40,30 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   });
   console.error(`[fetch] ${docs.length} docs`);
 
-  // Build id → slug map (without trailing .md; wikilinks omit extension).
+  // Build id → slug map. On collision, append short hash of id so distinct
+  // docs don't clobber each other. Track path uniqueness, not slug — two
+  // folders may share the same slug (e.g. learnings/foo.md + retros/foo.md).
   const slugById = new Map<string, string>();
+  const usedPaths = new Set<string>();
+  let slugCollisions = 0;
   for (const doc of docs) {
-    const rel = slugifyPath(doc.type, doc.id, doc.title ?? doc.id);
-    slugById.set(doc.id, rel.replace(/\.md$/, ""));
+    const base = slugifyPath(doc.type, doc.id, doc.title ?? doc.id).replace(/\.md$/, "");
+    let slug = base;
+    if (usedPaths.has(slug)) {
+      slugCollisions++;
+      const suffix = shortIdHash(doc.id);
+      slug = `${base}-${suffix}`;
+      // Very defensive: if even the suffixed slug collides, keep extending.
+      let n = 2;
+      while (usedPaths.has(slug)) {
+        slug = `${base}-${suffix}-${n++}`;
+      }
+    }
+    usedPaths.add(slug);
+    slugById.set(doc.id, slug);
+  }
+  if (slugCollisions > 0) {
+    console.error(`[slug] ${slugCollisions} collisions resolved via id-hash suffix`);
   }
   const slugForId = (id: string) => slugById.get(id) ?? id;
 

--- a/cli/src/plugins/export-obsidian/lib/slugify.ts
+++ b/cli/src/plugins/export-obsidian/lib/slugify.ts
@@ -42,6 +42,19 @@ export function slugifyPath(type: string, id: string, title: string): string {
   return `${folder}/${slug}.md`;
 }
 
+/**
+ * Short deterministic id hash for slug-collision disambiguation.
+ * Not cryptographic — FNV-1a 32-bit, base36, capped to 8 chars.
+ */
+export function shortIdHash(id: string, len = 8): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(36).padStart(len, "0").slice(-len);
+}
+
 function folderForType(type: string): string {
   const t = type.toLowerCase();
   if (t === "principle") return "principles";


### PR DESCRIPTION
40% data loss from slug clobbering. Track used paths, append FNV-1a id-hash suffix on collision. 323 tests pass.