### PR TITLE
feat(menu): Phase 3 DB-backed sub-navs backend

### DIFF
--- a/src/db/migrations/0008_menu_host.sql
+++ b/src/db/migrations/0008_menu_host.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `menu_items` ADD COLUMN `host` text;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1776574727337,
       "tag": "0007_add_menu_items",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1777248000000,
+      "tag": "0008_menu_host",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -305,6 +305,7 @@ export const menuItems = sqliteTable('menu_items', {
   access: text('access').notNull().default('public'),
   source: text('source').notNull(),
   icon: text('icon'),
+  host: text('host'),
   touchedAt: integer('touched_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),

--- a/src/routes/menu/__tests__/menu-phase3.test.ts
+++ b/src/routes/menu/__tests__/menu-phase3.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Phase 3 backend tests: parentId tree nesting, host glob filter, orphan fallback.
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { buildTree } from '../admin.ts';
+import { hostMatches } from '../menu.ts';
+
+type Row = Parameters<typeof buildTree>[0][number];
+
+const base = (over: Partial<Row>): Row => ({
+  id: 1,
+  path: '/x',
+  label: 'X',
+  groupKey: 'main',
+  parentId: null,
+  position: 0,
+  enabled: true,
+  access: 'public',
+  source: 'route',
+  icon: null,
+  host: null,
+  touchedAt: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  ...over,
+});
+
+describe('buildTree', () => {
+  it('nests children under matching parents', () => {
+    const rows = [
+      base({ id: 1, path: '/a', label: 'A', parentId: null, position: 0 }),
+      base({ id: 2, path: '/a/x', label: 'A.X', parentId: 1, position: 1 }),
+      base({ id: 3, path: '/a/y', label: 'A.Y', parentId: 1, position: 2 }),
+      base({ id: 4, path: '/b', label: 'B', parentId: null, position: 3 }),
+    ];
+    const tree = buildTree(rows);
+    expect(tree.map((n) => n.id)).toEqual([1, 4]);
+    const a = tree.find((n) => n.id === 1)!;
+    expect(a.children.map((c) => c.id)).toEqual([2, 3]);
+    expect(tree.find((n) => n.id === 4)!.children).toEqual([]);
+  });
+
+  it('promotes orphans (parentId → missing) to root-level', () => {
+    const rows = [
+      base({ id: 1, path: '/orphan', parentId: 999, position: 0 }),
+      base({ id: 2, path: '/keep', parentId: null, position: 1 }),
+    ];
+    const tree = buildTree(rows);
+    expect(tree.map((n) => n.id).sort()).toEqual([1, 2]);
+  });
+});
+
+describe('hostMatches', () => {
+  it('null pattern matches any host (show everywhere)', () => {
+    expect(hostMatches(null, 'vector.foo.com')).toBe(true);
+    expect(hostMatches(undefined, 'studio.bar.com')).toBe(true);
+  });
+
+  it('glob `vector.*` matches vector subdomains only', () => {
+    expect(hostMatches('vector.*', 'vector.foo.com')).toBe(true);
+    expect(hostMatches('vector.*', 'studio.foo.com')).toBe(false);
+  });
+
+  it('exact literal matches only itself', () => {
+    expect(hostMatches('studio.arra.dev', 'studio.arra.dev')).toBe(true);
+    expect(hostMatches('studio.arra.dev', 'studio.arra.dev.evil.com')).toBe(false);
+  });
+
+  it('escapes regex metachars so dots are literal', () => {
+    expect(hostMatches('vector.foo', 'vectorXfoo')).toBe(false);
+  });
+});

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -30,6 +30,7 @@ function toResponse(row: MenuRow) {
     access: row.access,
     source: row.source,
     icon: row.icon,
+    host: row.host,
     touchedAt: row.touchedAt ? row.touchedAt.getTime() : null,
     createdAt: row.createdAt.getTime(),
     updatedAt: row.updatedAt.getTime(),
@@ -39,7 +40,7 @@ function toResponse(row: MenuRow) {
 type ResponseRow = ReturnType<typeof toResponse>;
 type TreeNode = ResponseRow & { children: TreeNode[] };
 
-function buildTree(rows: MenuRow[]): TreeNode[] {
+export function buildTree(rows: MenuRow[]): TreeNode[] {
   const nodes = new Map<number, TreeNode>();
   for (const row of rows) nodes.set(row.id, { ...toResponse(row), children: [] });
   const roots: TreeNode[] = [];
@@ -103,6 +104,7 @@ export function createMenuAdminRoutes() {
               access: body.access ?? 'public',
               source: 'custom',
               icon: body.icon ?? null,
+              host: body.host ?? null,
               touchedAt: now,
               createdAt: now,
               updatedAt: now,
@@ -126,6 +128,7 @@ export function createMenuAdminRoutes() {
           enabled: t.Optional(t.Boolean()),
           access: t.Optional(AccessSchema),
           icon: t.Optional(t.String()),
+          host: t.Optional(t.Nullable(t.String())),
         }),
         detail: {
           tags: ['menu'],
@@ -151,6 +154,7 @@ export function createMenuAdminRoutes() {
         if (body.enabled !== undefined) patch.enabled = body.enabled;
         if (body.access !== undefined) patch.access = body.access;
         if (body.icon !== undefined) patch.icon = body.icon;
+        if (body.host !== undefined) patch.host = body.host;
 
         const updated = db
           .update(menuItems)
@@ -174,6 +178,7 @@ export function createMenuAdminRoutes() {
           enabled: t.Optional(t.Boolean()),
           access: t.Optional(AccessSchema),
           icon: t.Optional(t.Nullable(t.String())),
+          host: t.Optional(t.Nullable(t.String())),
         }),
         detail: {
           tags: ['menu'],

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -84,10 +84,23 @@ export function menuItemsFromRoutes(sources: HasRoutes[]): MenuItem[] {
 }
 
 /**
+ * Match a stored glob pattern (e.g. `vector.*`) against a concrete host
+ * (e.g. `vector.foo.com`). Only `*` is treated as a wildcard; other regex
+ * metacharacters are escaped.
+ */
+export function hostMatches(pattern: string | null | undefined, host: string): boolean {
+  if (pattern == null) return true;
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`).test(host);
+}
+
+/**
  * Read API-sourced menu items from the `menu_items` DB table.
  * Only enabled rows are returned. Source is always 'api' for studio consumers.
+ * When `host` is provided, rows are filtered to those with null `host` (shown
+ * everywhere) or a glob pattern matching the supplied host.
  */
-export function readApiMenuItemsFromDb(): MenuItem[] {
+export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
   const rows = db
     .select()
     .from(menuItems)
@@ -97,6 +110,7 @@ export function readApiMenuItemsFromDb(): MenuItem[] {
   const items: MenuItem[] = [];
   for (const row of rows) {
     if (row.enabled === false) continue;
+    if (host !== undefined && !hostMatches(row.host, host)) continue;
     const group = (['main', 'tools', 'admin', 'hidden'] as const).includes(
       row.groupKey as MenuItem['group'],
     )
@@ -181,17 +195,19 @@ export function createMenuEndpoint() {
   return new Elysia()
     .get(
       '/menu',
-      async () => {
+      async ({ query }) => {
         const { items, disable } = await getMenuConfig();
+        const host = typeof query.host === 'string' && query.host.length > 0 ? query.host : undefined;
         return {
           items: buildMenuItems(
-            readApiMenuItemsFromDb(),
+            readApiMenuItemsFromDb(host),
             { items, disable },
             listCustomMenuItems(),
           ),
         };
       },
       {
+        query: t.Object({ host: t.Optional(t.String()) }),
         detail: {
           tags: ['menu'],
           menu: { group: 'hidden' },


### PR DESCRIPTION
Backend only — adds `host` column + glob host filter to `menu_items`. `parentId` already existed, so migration just adds `host`. `/menu/tree` keeps its existing parent-id nesting; orphan rows (parentId → missing) fall back to root.

## Changes
- `src/db/schema.ts` — new `host` text column
- `src/db/migrations/0008_menu_host.sql` — `ALTER TABLE menu_items ADD COLUMN host text`
- `src/routes/menu/menu.ts` — `hostMatches()` glob matcher + `readApiMenuItemsFromDb(host)` + `GET /api/menu?host=...`
- `src/routes/menu/admin.ts` — include `host` in row responses, accept in POST/PATCH bodies; `buildTree` exported for tests
- `src/routes/menu/__tests__/menu-phase3.test.ts` — 6 tests (tree nesting, orphan fallback, host glob matching, metachar escaping)

Frontend work (studio editor tree, vector DB-driven sub-nav) filed as follow-up issues.

## Test
- `bun test` → 538 pass, 0 fail
- `bun run build` (tsc) → clean

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle