### PR TITLE
feat(menu): add hidden column to menu_items (#948)

### DIFF
--- a/src/db/migrations/0009_menu_hidden.sql
+++ b/src/db/migrations/0009_menu_hidden.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `menu_items` ADD COLUMN `hidden` integer DEFAULT 0 NOT NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777248000000,
       "tag": "0008_menu_host",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1777852800000,
+      "tag": "0009_menu_hidden",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -306,6 +306,7 @@ export const menuItems = sqliteTable('menu_items', {
   source: text('source').notNull(),
   icon: text('icon'),
   host: text('host'),
+  hidden: integer('hidden', { mode: 'boolean' }).notNull().default(false),
   touchedAt: integer('touched_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),

--- a/src/routes/menu/__tests__/menu-hidden.test.ts
+++ b/src/routes/menu/__tests__/menu-hidden.test.ts
@@ -1,0 +1,77 @@
+/**
+ * #948: hidden column round-trip.
+ * Exercises toResponse (admin list) and readApiMenuItemsFromDb (/api/menu).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { toResponse } from '../admin.ts';
+import { readApiMenuItemsFromDb } from '../menu.ts';
+import { db, menuItems } from '../../../db/index.ts';
+
+type Row = Parameters<typeof toResponse>[0];
+
+const row = (over: Partial<Row>): Row => ({
+  id: 1,
+  path: '/x',
+  label: 'X',
+  groupKey: 'main',
+  parentId: null,
+  position: 0,
+  enabled: true,
+  access: 'public',
+  source: 'route',
+  icon: null,
+  host: null,
+  hidden: false,
+  touchedAt: null,
+  createdAt: new Date(0),
+  updatedAt: new Date(0),
+  ...over,
+});
+
+describe('toResponse — hidden field', () => {
+  it('defaults hidden:false in response', () => {
+    expect(toResponse(row({})).hidden).toBe(false);
+  });
+
+  it('passes hidden:true through', () => {
+    expect(toResponse(row({ hidden: true })).hidden).toBe(true);
+  });
+});
+
+describe('menu_items hidden column — DB round-trip', () => {
+  it('persists hidden:true and surfaces it on admin list + /api/menu', () => {
+    const now = new Date();
+    const path = `/__hidden_test_${Date.now()}`;
+
+    try {
+      const inserted = db
+        .insert(menuItems)
+        .values({
+          path,
+          label: 'Hidden Test',
+          groupKey: 'tools',
+          position: 500,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          hidden: true,
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+        .get();
+
+      expect(inserted.hidden).toBe(true);
+      expect(toResponse(inserted).hidden).toBe(true);
+
+      const apiItem = readApiMenuItemsFromDb().find((i) => i.path === path);
+      expect(apiItem).toBeDefined();
+      expect(apiItem!.hidden).toBe(true);
+    } finally {
+      db.delete(menuItems).where(eq(menuItems.path, path)).run();
+    }
+  });
+});

--- a/src/routes/menu/__tests__/menu-phase3.test.ts
+++ b/src/routes/menu/__tests__/menu-phase3.test.ts
@@ -20,6 +20,7 @@ const base = (over: Partial<Row>): Row => ({
   source: 'route',
   icon: null,
   host: null,
+  hidden: false,
   touchedAt: null,
   createdAt: new Date(0),
   updatedAt: new Date(0),

--- a/src/routes/menu/admin.ts
+++ b/src/routes/menu/admin.ts
@@ -18,7 +18,7 @@ const GroupSchema = t.Union([
 ]);
 const AccessSchema = t.Union([t.Literal('public'), t.Literal('auth')]);
 
-function toResponse(row: MenuRow) {
+export function toResponse(row: MenuRow) {
   return {
     id: row.id,
     path: row.path,
@@ -31,6 +31,7 @@ function toResponse(row: MenuRow) {
     source: row.source,
     icon: row.icon,
     host: row.host,
+    hidden: row.hidden,
     touchedAt: row.touchedAt ? row.touchedAt.getTime() : null,
     createdAt: row.createdAt.getTime(),
     updatedAt: row.updatedAt.getTime(),
@@ -105,6 +106,7 @@ export function createMenuAdminRoutes() {
               source: 'custom',
               icon: body.icon ?? null,
               host: body.host ?? null,
+              hidden: body.hidden ?? false,
               touchedAt: now,
               createdAt: now,
               updatedAt: now,
@@ -129,6 +131,7 @@ export function createMenuAdminRoutes() {
           access: t.Optional(AccessSchema),
           icon: t.Optional(t.String()),
           host: t.Optional(t.Nullable(t.String())),
+          hidden: t.Optional(t.Boolean()),
         }),
         detail: {
           tags: ['menu'],
@@ -155,6 +158,7 @@ export function createMenuAdminRoutes() {
         if (body.access !== undefined) patch.access = body.access;
         if (body.icon !== undefined) patch.icon = body.icon;
         if (body.host !== undefined) patch.host = body.host;
+        if (body.hidden !== undefined) patch.hidden = body.hidden;
 
         const updated = db
           .update(menuItems)
@@ -179,6 +183,7 @@ export function createMenuAdminRoutes() {
           access: t.Optional(AccessSchema),
           icon: t.Optional(t.Nullable(t.String())),
           host: t.Optional(t.Nullable(t.String())),
+          hidden: t.Optional(t.Boolean()),
         }),
         detail: {
           tags: ['menu'],

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -125,6 +125,7 @@ export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
     };
     if (row.icon) item.icon = row.icon;
     if (row.access === 'public' || row.access === 'auth') item.access = row.access;
+    if (row.hidden) item.hidden = true;
     items.push(item);
   }
   return items;

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -38,6 +38,7 @@ export const MenuItemSchema = t.Object({
     t.Literal('plugin'),
   ]),
   added: t.Optional(t.Boolean()),
+  hidden: t.Optional(t.Boolean()),
 });
 
 export type MenuItem = Static<typeof MenuItemSchema>;


### PR DESCRIPTION
## Summary

- Adds `hidden` boolean column to `menu_items` (SQLite INTEGER DEFAULT 0 NOT NULL)
- Admin POST/PATCH accept optional `hidden`; admin list + `/api/menu` emit it
- Frontend (VectorSubNav + studio menu editor) already reads `item.hidden` optimistically — wiring it up backend-side makes the soft-hide toggle Just Work

## Changes

| File | Δ |
|---|---|
| `src/db/migrations/0009_menu_hidden.sql` | new — `ALTER TABLE menu_items ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0` |
| `src/db/migrations/meta/_journal.json` | + 0009 entry |
| `src/db/schema.ts` | +`hidden: integer('hidden', { mode: 'boolean' }).notNull().default(false)` |
| `src/routes/menu/admin.ts` | `toResponse` exports + emits `hidden`; POST/PATCH bodies accept optional `hidden` |
| `src/routes/menu/menu.ts` | `readApiMenuItemsFromDb` passes `hidden` through when truthy |
| `src/routes/menu/model.ts` | `MenuItemSchema` gains optional `hidden` |
| `src/routes/menu/__tests__/menu-hidden.test.ts` | new — round-trip DB insert → `toResponse` + `/api/menu` read |
| `src/routes/menu/__tests__/menu-phase3.test.ts` | base row fixture +`hidden: false` |

Total: +95 / -1 across 8 files.

## Test plan

- [x] `bun test src/routes/menu/__tests__/` → 9 pass / 0 fail
- [ ] Boot server, `POST /api/menu/items {hidden:true}`, then `GET /api/menu/items` → item has `hidden:true`
- [ ] `GET /api/menu` → same item visible, `hidden:true` in response
- [ ] `PATCH /api/menu/items/:id {hidden:false}` → round-trip back to false
- [ ] Existing row defaults to `hidden:false` after migration

Closes #948

---

🤖 ตอบโดย arra-oracle-v3 (backend-eng) จาก [Nat] → arra-oracle-v3-oracle