### PR TITLE
fix(feed): add POST /api/vault/sync manual trigger (#926)

### DIFF
--- a/src/routes/vault/__tests__/sync.test.ts
+++ b/src/routes/vault/__tests__/sync.test.ts
@@ -1,0 +1,88 @@
+/**
+ * #926 short-term fix: POST /api/vault/sync route wiring.
+ * Uses the createVaultSyncRoute factory so migrate + spawn can be stubbed.
+ */
+
+import { describe, it, expect, mock } from 'bun:test';
+import { Elysia } from 'elysia';
+import { createVaultSyncRoute } from '../sync.ts';
+import type { MigrateResult } from '../../../vault/migrate.ts';
+
+const emptyMigrate: MigrateResult = {
+  reposFound: 0,
+  filesCopied: 0,
+  repos: [],
+  skipped: [],
+  symlinked: [],
+};
+
+function post(app: Elysia, body: unknown) {
+  return app.handle(
+    new Request('http://localhost/sync', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe('POST /sync', () => {
+  it('dryRun=true passes through to migrate and never spawns reindex', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, reposFound: 2, filesCopied: 5 }));
+    const spawnIndexer = mock(() => {});
+    const app = new Elysia().use(createVaultSyncRoute({ migrate, spawnIndexer }));
+
+    const res = await post(app, { dryRun: true, reindex: true });
+    const body = (await res.json()) as any;
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.dryRun).toBe(true);
+    expect(body.reindex).toBe(false);
+    expect(body.migrate.filesCopied).toBe(5);
+    expect(migrate).toHaveBeenCalledTimes(1);
+    expect(migrate.mock.calls[0]?.[0]).toEqual({ dryRun: true });
+    expect(spawnIndexer).not.toHaveBeenCalled();
+  });
+
+  it('reindex=true spawns indexer only when files were actually copied', async () => {
+    const migrate = mock(() => ({ ...emptyMigrate, reposFound: 3, filesCopied: 42 }));
+    const spawnIndexer = mock(() => {});
+    const app = new Elysia().use(createVaultSyncRoute({ migrate, spawnIndexer }));
+
+    const res = await post(app, { reindex: true });
+    const body = (await res.json()) as any;
+
+    expect(body.ok).toBe(true);
+    expect(body.reindex).toBe(true);
+    expect(spawnIndexer).toHaveBeenCalledTimes(1);
+  });
+
+  it('reindex=true skips spawn when filesCopied=0', async () => {
+    const migrate = mock(() => emptyMigrate);
+    const spawnIndexer = mock(() => {});
+    const app = new Elysia().use(createVaultSyncRoute({ migrate, spawnIndexer }));
+
+    const res = await post(app, { reindex: true });
+    const body = (await res.json()) as any;
+
+    expect(body.ok).toBe(true);
+    expect(body.reindex).toBe(false);
+    expect(spawnIndexer).not.toHaveBeenCalled();
+  });
+
+  it('surfaces migrate() errors as 500', async () => {
+    const migrate = mock(() => {
+      throw new Error('Vault not initialized. Run vault:init first.');
+    });
+    const spawnIndexer = mock(() => {});
+    const app = new Elysia().use(createVaultSyncRoute({ migrate, spawnIndexer }));
+
+    const res = await post(app, {});
+    const body = (await res.json()) as any;
+
+    expect(res.status).toBe(500);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('Vault not initialized');
+  });
+});

--- a/src/routes/vault/index.ts
+++ b/src/routes/vault/index.ts
@@ -1,0 +1,13 @@
+import { Elysia } from 'elysia';
+import { SESSION_COOKIE_NAME, isAuthenticated } from '../auth/index.ts';
+import { vaultSyncRoute } from './sync.ts';
+
+export const vaultRoutes = new Elysia({ prefix: '/api/vault' })
+  .onBeforeHandle(({ server, request, cookie, set }) => {
+    const sessionValue = cookie[SESSION_COOKIE_NAME]?.value as string | undefined;
+    if (!isAuthenticated(server, request, sessionValue)) {
+      set.status = 401;
+      return { error: 'Unauthorized', requiresAuth: true };
+    }
+  })
+  .use(vaultSyncRoute);

--- a/src/routes/vault/sync.ts
+++ b/src/routes/vault/sync.ts
@@ -1,0 +1,74 @@
+/**
+ * POST /api/vault/sync — short-term fix for #926.
+ *
+ * Calls `migrate()` to pull every ghq repo's ψ/ into the aggregate vault
+ * (what `oracle-vault migrate` does on the CLI), then optionally triggers
+ * a background reindex so /api/list?type=retro surfaces fresh entries.
+ *
+ * Longer fix: multi-root indexer scan or push-on-save from /rrr writes.
+ */
+
+import { Elysia, t } from 'elysia';
+import { migrate as runMigrate, type MigrateResult } from '../../vault/migrate.ts';
+
+export interface SyncDeps {
+  migrate: (opts: { dryRun: boolean }) => MigrateResult;
+  spawnIndexer: () => void;
+}
+
+const defaultDeps: SyncDeps = {
+  migrate: runMigrate,
+  spawnIndexer: () => {
+    Bun.spawn(['bun', 'run', 'src/indexer/cli.ts'], {
+      cwd: process.cwd(),
+      stdout: 'inherit',
+      stderr: 'inherit',
+    });
+  },
+};
+
+export function createVaultSyncRoute(deps: SyncDeps = defaultDeps) {
+  return new Elysia().post(
+    '/sync',
+    ({ body, set }) => {
+      const dryRun = body?.dryRun === true;
+      const reindex = body?.reindex === true;
+
+      try {
+        const result = deps.migrate({ dryRun });
+
+        let reindexSpawned = false;
+        if (reindex && !dryRun && result.filesCopied > 0) {
+          deps.spawnIndexer();
+          reindexSpawned = true;
+        }
+
+        return {
+          ok: true,
+          dryRun,
+          reindex: reindexSpawned,
+          migrate: result,
+        };
+      } catch (err) {
+        set.status = 500;
+        return { ok: false, error: (err as Error).message };
+      }
+    },
+    {
+      body: t.Optional(
+        t.Object({
+          dryRun: t.Optional(t.Boolean()),
+          reindex: t.Optional(t.Boolean()),
+        }),
+      ),
+      detail: {
+        tags: ['vault'],
+        menu: { group: 'admin', order: 950 },
+        summary:
+          'Pull all ghq ψ/ dirs into the aggregate vault (short-term #926 fix); optional background reindex',
+      },
+    },
+  );
+}
+
+export const vaultSyncRoute = createVaultSyncRoute();

--- a/src/server.ts
+++ b/src/server.ts
@@ -40,6 +40,7 @@ import { filesRouter } from './routes/files/index.ts';
 import { pluginsRouter } from './routes/plugins/index.ts';
 import { oraclenetRoutes } from './routes/oraclenet/index.ts';
 import { sessionsRoutes } from './routes/sessions/index.ts';
+import { vaultRoutes } from './routes/vault/index.ts';
 import { createMenuRoutes } from './routes/menu/index.ts';
 
 import pkg from '../package.json' with { type: 'json' };
@@ -180,6 +181,7 @@ const apiModules = [
   pluginsRouter,
   oraclenetRoutes,
   sessionsRoutes,
+  vaultRoutes,
 ];
 
 try {


### PR DESCRIPTION
## Summary

Short-term fix for #926 — `/api/list?type=retro` showing only entries up to `2026-03-03`.

**Root cause**: indexer reads from the oracle-vault aggregator; that aggregate is only updated when someone runs `oracle-vault migrate` by hand. Newer per-oracle retros (e.g. `arra-oracle-v3-oracle/ψ/memory/retrospectives/2026-04-*`) never propagate.

**Fix**: expose the CLI behavior as an HTTP endpoint so it can be triggered without shelling in.

## Changes

| File | Δ |
|---|---|
| `src/routes/vault/sync.ts` | new — `POST /sync` via `createVaultSyncRoute` factory (DI for tests) + default singleton (`migrate()` + optional `Bun.spawn` reindex) |
| `src/routes/vault/index.ts` | new — `/api/vault` prefix + auth guard (mirrors settingsRoutes) |
| `src/routes/vault/__tests__/sync.test.ts` | new — 4 unit tests |
| `src/server.ts` | register `vaultRoutes` in `apiModules` |

Total: +177 / 0 across 4 files. No changes to existing vault CLI (`src/vault/cli.ts`) or indexer.

## Endpoint

\`\`\`
POST /api/vault/sync
Content-Type: application/json

{ \"dryRun\": false, \"reindex\": true }
\`\`\`

- \`dryRun:true\` returns the migrate preview without copying
- \`reindex:true\` spawns \`bun run src/indexer/cli.ts\` in the background once \`filesCopied > 0\`
- Requires auth (same session-cookie guard as /api/settings)

## Test plan

- [x] `bun test src/routes/vault/` → 4 pass / 0 fail
- [ ] Boot server, `curl -X POST -H 'content-type: application/json' -d '{\"dryRun\":true}' /api/vault/sync` → returns preview JSON with reposFound/filesCopied
- [ ] `curl -X POST -H 'content-type: application/json' -d '{\"reindex\":true}' /api/vault/sync` → filesCopied > 0, indexer spawned
- [ ] After indexer finishes: `curl '/api/list?type=retro&limit=5'` shows 2026-04-* retros
- [ ] Feed UI at /feed shows last 30 days of retros

## Longer-term options (not in this PR)

- Auto-invoke vault sync on `/rrr` writes (push-on-save)
- Indexer multi-root scan: oracle-vault aggregator + live per-oracle `ψ/` dirs
- Cron-triggered sync

Refs #926

---

🤖 ตอบโดย arra-oracle-v3 (backend-eng) จาก [Nat] → arra-oracle-v3-oracle