### PR TITLE
fix(tests): durable ChromaMcp adapter tests — 30s timeout, no gate (closes #897)

### DIFF
--- a/src/vector/__tests__/adapters.test.ts
+++ b/src/vector/__tests__/adapters.test.ts
@@ -240,17 +240,15 @@ describe('SqliteVecAdapter + Ollama', () => {
 });
 
 // ============================================================================
-// ChromaMcpAdapter (opt-in only — set CHROMA_MCP_TESTS=1 to run)
+// ChromaMcpAdapter
 // ============================================================================
-// These tests spawn a chroma-mcp stdio subprocess and pass when run in
-// isolation (`bun test src/vector/__tests__/adapters.test.ts`), but flake
-// under the full-suite run from repo root — the subprocess handshake races
-// with other concurrent test processes and bun's default 5s test timeout
-// fires during addDocuments. Opt-in via CHROMA_MCP_TESTS=1 for targeted
-// coverage; see GH issue for a durable fix (spawn timing / retry).
-const runChromaMcpTests = process.env.CHROMA_MCP_TESTS === '1';
+// Spawns a `uvx chroma-mcp` stdio subprocess. The subprocess cold-start
+// (uv fetching/resolving the Python env) can take several seconds under
+// full-suite concurrency, so each test here needs a timeout well above
+// bun's 5s default. Tests auto-skip if uvx/chroma-mcp is unavailable.
+const CHROMA_TEST_TIMEOUT_MS = 30_000;
 
-(runChromaMcpTests ? describe : describe.skip)('ChromaMcpAdapter', () => {
+describe('ChromaMcpAdapter', () => {
   let store: VectorStoreAdapter;
   let chromaAvailable = false;
 
@@ -282,7 +280,7 @@ const runChromaMcpTests = process.env.CHROMA_MCP_TESTS === '1';
     await store.ensureCollection();
     const info = await store.getCollectionInfo();
     expect(info.name).toBe('oracle_test_adapter');
-  });
+  }, CHROMA_TEST_TIMEOUT_MS);
 
   test('addDocuments + query', async () => {
     if (!chromaAvailable) { console.log('  [SKIP] ChromaDB not available'); return; }
@@ -294,7 +292,7 @@ const runChromaMcpTests = process.env.CHROMA_MCP_TESTS === '1';
     const result = await store.query('git history', 3);
     expect(result.ids.length).toBeGreaterThan(0);
     expect(result.documents.length).toBe(result.ids.length);
-  });
+  }, CHROMA_TEST_TIMEOUT_MS);
 
   test.skip('queryById (pre-existing safeJsonParse single-quote bug)', async () => {
     if (!chromaAvailable) { console.log('  [SKIP] ChromaDB not available'); return; }
@@ -302,7 +300,7 @@ const runChromaMcpTests = process.env.CHROMA_MCP_TESTS === '1';
     const result = await store.queryById('test_1', 2);
     expect(result.ids.length).toBeGreaterThan(0);
     expect(result.ids).not.toContain('test_1');
-  });
+  }, CHROMA_TEST_TIMEOUT_MS);
 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- ChromaMcp adapter tests no longer need `CHROMA_MCP_TESTS=1` — each test gets a 30 s timeout so the `uvx chroma-mcp` subprocess cold-start no longer hits bun's 5 s default.
- Tests still auto-skip if `uvx` / `chroma-mcp` is unavailable (existing `chromaAvailable` guard in `setup()`), so CI without Python tooling stays green.
- Net diff: +11 / −13 in one file.

## Why per-test timeout over retry/backoff

Repro (`bun test` from repo root, `CHROMA_MCP_TESTS=1` forced): only `ChromaMcpAdapter > addDocuments + query` failed, at exactly `[5001.00ms]`. Root cause is bun's 5 s cap firing mid-work, not a racy handshake — `connect + ensureCollection` already succeeded in the same run. A larger per-test budget is the minimal, targeted fix.

## Flake verification

10 consecutive `bun test` runs from repo root, no env var set:

| Run | Result |
|---|---|
| 1 | 540 pass / 0 fail |
| 2 | 540 pass / 0 fail |
| 3 | 540 pass / 0 fail |
| 4 | 540 pass / 0 fail |
| 5 | 539 pass / 1 fail — **unrelated**; ChromaMcp suite green (network-flaky gist-fetch test) |
| 6 | 540 pass / 0 fail |
| 7 | 540 pass / 0 fail |
| 8 | 540 pass / 0 fail |
| 9 | 540 pass / 0 fail |
| 10 | 540 pass / 0 fail |

ChromaMcp tests (`connect + ensureCollection`, `addDocuments + query`) passed in **all 10** runs. Closes #897.

## Test plan

- [x] `bun test` from repo root passes without `CHROMA_MCP_TESTS=1`
- [x] ChromaMcp suite green across ≥5 consecutive runs
- [x] Adapter still skips cleanly when `uvx` unavailable

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle