### PR TITLE
feat(menu): submenu reorg via parentId — Tools + Canvas (closes #958)

### DIFF
--- a/src/db/migrations/0011_menu_reorg.sql
+++ b/src/db/migrations/0011_menu_reorg.sql
@@ -1,0 +1,38 @@
+-- #958 submenu reorg: parentId-driven Tools + Canvas parents,
+-- reparent children, demote duplicate Feed/Schedule main rows.
+
+INSERT OR IGNORE INTO menu_items
+  (path, label, group_key, parent_id, position, enabled, access, source, touched_at, created_at, updated_at)
+VALUES
+  ('#tools',  'Tools',  'main', NULL, 40, 1, 'public', 'custom', unixepoch(), unixepoch(), unixepoch()),
+  ('#canvas', 'Canvas', 'main', NULL, 50, 1, 'public', 'custom', unixepoch(), unixepoch(), unixepoch());
+--> statement-breakpoint
+UPDATE menu_items
+SET parent_id = (SELECT id FROM menu_items WHERE path = '#tools'),
+    group_key = 'main',
+    touched_at = unixepoch(),
+    updated_at = unixepoch()
+WHERE path IN ('/playground', '/forum', '/plugins', '/evolution', '/pulse')
+  AND parent_id IS NULL;
+--> statement-breakpoint
+UPDATE menu_items
+SET parent_id = (SELECT id FROM menu_items WHERE path = '#canvas'),
+    group_key = 'main',
+    query = COALESCE(query, '{"plugin":"map"}'),
+    touched_at = unixepoch(),
+    updated_at = unixepoch()
+WHERE path = '/map' AND parent_id IS NULL;
+--> statement-breakpoint
+INSERT OR IGNORE INTO menu_items
+  (path, label, group_key, parent_id, position, enabled, access, source, query, touched_at, created_at, updated_at)
+VALUES
+  ('/planets', 'Planets', 'main',
+   (SELECT id FROM menu_items WHERE path = '#canvas'),
+   20, 1, 'public', 'custom', '{"plugin":"planets"}',
+   unixepoch(), unixepoch(), unixepoch());
+--> statement-breakpoint
+UPDATE menu_items
+SET group_key = 'hidden',
+    touched_at = unixepoch(),
+    updated_at = unixepoch()
+WHERE path IN ('/feed', '/schedule') AND group_key = 'main';

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778457600000,
       "tag": "0010_menu_query",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1778803200000,
+      "tag": "0011_menu_reorg",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -70,6 +70,20 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
   return rows;
 }
 
+/**
+ * #958: submenu reparenting. Migration 0011 owns parent-row creation and
+ * data-migration on existing installs; the seeder only reconciles known
+ * children on every boot so route-seeded rows drop under the right parent.
+ */
+const CHILD_PARENTS: Record<string, string> = {
+  '/playground': '#tools',
+  '/forum': '#tools',
+  '/plugins': '#tools',
+  '/evolution': '#tools',
+  '/pulse': '#tools',
+  '/map': '#canvas',
+};
+
 export interface SeedResult {
   inserted: number;
   updated: number;
@@ -139,6 +153,25 @@ export function seedMenuItems(
       }
 
       preserved += 1;
+    }
+
+    for (const [childPath, parentPath] of Object.entries(CHILD_PARENTS)) {
+      const parent = tx
+        .select()
+        .from(schema.menuItems)
+        .where(eq(schema.menuItems.path, parentPath))
+        .get();
+      if (!parent) continue;
+      const child = tx
+        .select()
+        .from(schema.menuItems)
+        .where(eq(schema.menuItems.path, childPath))
+        .get();
+      if (!child || child.parentId === parent.id) continue;
+      tx.update(schema.menuItems)
+        .set({ parentId: parent.id, updatedAt: now })
+        .where(eq(schema.menuItems.id, child.id))
+        .run();
     }
   });
 

--- a/src/routes/menu/__tests__/menu-reorg.test.ts
+++ b/src/routes/menu/__tests__/menu-reorg.test.ts
@@ -1,0 +1,95 @@
+/**
+ * #958 submenu reorg: verify seeder's reparent post-pass wires known
+ * children to Tools/Canvas parents. Migration 0011 owns parent-row
+ * creation + /feed+/schedule demotion + Planets seed; this suite only
+ * covers the seeder contract on top of that.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { eq, inArray } from 'drizzle-orm';
+import { db, menuItems } from '../../../db/index.ts';
+import { seedMenuItems } from '../../../db/seeders/menu-seeder.ts';
+import { buildTree } from '../admin.ts';
+
+const CHILD_PATHS = ['/playground', '/forum', '/plugins', '/evolution', '/pulse', '/map'] as const;
+const ALL_PATHS = ['#tools', '#canvas', '/planets', ...CHILD_PATHS] as const;
+
+function insertParent(path: string, label: string, position: number): number {
+  const now = new Date();
+  return db.insert(menuItems).values({
+    path, label, groupKey: 'main', position,
+    enabled: true, access: 'public', source: 'custom',
+    touchedAt: now, createdAt: now, updatedAt: now,
+  }).returning().get().id;
+}
+
+function insertChild(path: string, position: number): number {
+  const now = new Date();
+  return db.insert(menuItems).values({
+    path, label: `seed ${path}`,
+    groupKey: path === '/map' ? 'tools' : 'main',
+    position, enabled: true, access: 'public', source: 'route',
+    createdAt: now, updatedAt: now,
+  }).returning().get().id;
+}
+
+function insertCanvasChild(path: string, position: number, query: string, canvasId: number): number {
+  const now = new Date();
+  return db.insert(menuItems).values({
+    path, label: `seed ${path}`, groupKey: 'main',
+    parentId: canvasId, position, enabled: true, access: 'public', source: 'custom',
+    query, touchedAt: now, createdAt: now, updatedAt: now,
+  }).returning().get().id;
+}
+
+describe('#958 submenu reorg — seeder reparent post-pass', () => {
+  let toolsId = 0;
+  let canvasId = 0;
+
+  beforeAll(() => {
+    db.delete(menuItems).where(inArray(menuItems.path, ALL_PATHS as unknown as string[])).run();
+    toolsId = insertParent('#tools', 'Tools', 40);
+    canvasId = insertParent('#canvas', 'Canvas', 50);
+    CHILD_PATHS.forEach((p, i) => insertChild(p, 100 + i));
+    insertCanvasChild('/planets', 20, '{"plugin":"planets"}', canvasId);
+    seedMenuItems([]);
+  });
+
+  afterAll(() => {
+    db.delete(menuItems).where(inArray(menuItems.path, ALL_PATHS as unknown as string[])).run();
+  });
+
+  it('reparents five Tools children', () => {
+    for (const p of ['/playground', '/forum', '/plugins', '/evolution', '/pulse']) {
+      const row = db.select().from(menuItems).where(eq(menuItems.path, p)).get();
+      expect(row?.parentId, `parent of ${p}`).toBe(toolsId);
+    }
+  });
+
+  it('reparents /map under Canvas without clobbering groupKey', () => {
+    const map = db.select().from(menuItems).where(eq(menuItems.path, '/map')).get();
+    expect(map?.parentId).toBe(canvasId);
+    expect(map?.groupKey).toBe('tools');
+  });
+
+  it('leaves Planets (custom row) under Canvas with query payload', () => {
+    const planets = db.select().from(menuItems).where(eq(menuItems.path, '/planets')).get();
+    expect(planets?.parentId).toBe(canvasId);
+    expect(planets?.query).toBe('{"plugin":"planets"}');
+  });
+
+  it('second seedMenuItems call is a no-op (reparenting is idempotent)', () => {
+    const result = seedMenuItems([]);
+    expect(result).toEqual({ inserted: 0, updated: 0, preserved: 0 });
+  });
+
+  it('buildTree surfaces Tools w/ 5 children and Canvas w/ 2', () => {
+    const rows = db.select().from(menuItems).where(inArray(menuItems.path, ALL_PATHS as unknown as string[])).all();
+    const tree = buildTree(rows);
+    const tools = tree.find((n) => n.path === '#tools');
+    const canvas = tree.find((n) => n.path === '#canvas');
+    expect(tools?.children.length).toBe(5);
+    expect(canvas?.children.length).toBe(2);
+    expect(canvas?.children.map((c) => c.path).sort()).toEqual(['/map', '/planets']);
+  });
+});


### PR DESCRIPTION
## Summary

Migration 0011: submenu reorg via parentId. Adds Tools + Canvas parent rows, reparents existing children, seeds Canvas deep-link targets.

Rebased after #959 (query column) squash-merged — supersedes #960.

Closes #958.

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle