### PR TITLE
feat(menu): add parentId to /api/menu for shared-ui nesting

### DIFF
--- a/src/routes/menu/__tests__/menu-parent-id.test.ts
+++ b/src/routes/menu/__tests__/menu-parent-id.test.ts
@@ -1,0 +1,68 @@
+/**
+ * #949 follow-up: parentId round-trip on /api/menu.
+ * Shared-ui's buildNavSet attaches children by id/parentId, so the public
+ * endpoint must expose both as strings (DB column is integer).
+ */
+
+import { describe, it, expect } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { readApiMenuItemsFromDb } from '../menu.ts';
+import { db, menuItems } from '../../../db/index.ts';
+
+describe('readApiMenuItemsFromDb — id + parentId', () => {
+  it('exposes id and parentId as strings so buildNavSet can attach children', () => {
+    const now = new Date();
+    const parentPath = `/__parent_${Date.now()}`;
+    const childPath = `${parentPath}/kid`;
+
+    try {
+      const parent = db
+        .insert(menuItems)
+        .values({
+          path: parentPath,
+          label: 'Parent',
+          groupKey: 'tools',
+          position: 700,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning()
+        .get();
+
+      db
+        .insert(menuItems)
+        .values({
+          path: childPath,
+          label: 'Child',
+          groupKey: 'tools',
+          parentId: parent.id,
+          position: 701,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      const items = readApiMenuItemsFromDb();
+      const parentItem = items.find((i) => i.path === parentPath);
+      const childItem = items.find((i) => i.path === childPath);
+
+      expect(parentItem).toBeDefined();
+      expect(parentItem!.id).toBe(String(parent.id));
+      expect(parentItem!.parentId).toBeNull();
+
+      expect(childItem).toBeDefined();
+      expect(childItem!.parentId).toBe(String(parent.id));
+    } finally {
+      db.delete(menuItems).where(eq(menuItems.path, childPath)).run();
+      db.delete(menuItems).where(eq(menuItems.path, parentPath)).run();
+    }
+  });
+});

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -117,6 +117,8 @@ export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
       ? (row.groupKey as MenuItem['group'])
       : 'hidden';
     const item: MenuItem = {
+      id: String(row.id),
+      parentId: row.parentId == null ? null : String(row.parentId),
       path: row.path,
       label: row.label,
       group,

--- a/src/routes/menu/model.ts
+++ b/src/routes/menu/model.ts
@@ -20,6 +20,8 @@ declare module 'elysia' {
 }
 
 export const MenuItemSchema = t.Object({
+  id: t.Optional(t.String()),
+  parentId: t.Optional(t.Nullable(t.String())),
   path: t.String(),
   label: t.String(),
   group: t.Union([


### PR DESCRIPTION
## Summary

- `/api/menu` public response now includes `id` and `parentId` as strings
- `buildNavSet` in shared-ui already attaches children by `id`/`parentId` — but the public endpoint was silently dropping both, so the submenu reorg from #958 never reached studio consumers
- DB column is `integer`; mapped via `String(row.id)` / `row.parentId == null ? null : String(row.parentId)` to match shared-ui's `MenuApiItem` shape

## Why

Gap identified in the 2026-04-20 menu active-state audit (plan PR 5). `parentId` lives in `menu_items` (schema) and ships out of the admin tree endpoint, but the public consumer path was missing it, so nothing nests.

## Test plan

- [x] New test: `src/routes/menu/__tests__/menu-parent-id.test.ts` — DB round-trip asserting both fields survive to `/api/menu`
- [x] `bun test src/routes/menu` — 20 pass, 0 fail
- [x] Full `bun test` — only pre-existing `POST /api/handoff` failure unrelated to this change

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle