### PR TITLE
feat(menu): add studio TEXT column to menu_items

### DIFF
--- a/src/db/migrations/0012_menu_studio.sql
+++ b/src/db/migrations/0012_menu_studio.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `menu_items` ADD COLUMN `studio` text;
+--> statement-breakpoint
+UPDATE menu_items SET studio = 'studio.buildwithoracle.com', updated_at = unixepoch() WHERE path = '/search' AND studio IS NULL;
+--> statement-breakpoint
+UPDATE menu_items SET studio = 'feed.buildwithoracle.com', updated_at = unixepoch() WHERE path = '/feed' AND studio IS NULL;
+--> statement-breakpoint
+UPDATE menu_items SET studio = 'schedule.buildwithoracle.com', updated_at = unixepoch() WHERE path = '/schedule' AND studio IS NULL;
+--> statement-breakpoint
+UPDATE menu_items SET studio = 'canvas.buildwithoracle.com', updated_at = unixepoch() WHERE path IN ('/map', '/planets', '#canvas') AND studio IS NULL;

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778803200000,
       "tag": "0011_menu_reorg",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1779321600000,
+      "tag": "0012_menu_studio",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -308,6 +308,7 @@ export const menuItems = sqliteTable('menu_items', {
   host: text('host'),
   hidden: integer('hidden', { mode: 'boolean' }).notNull().default(false),
   query: text('query'),
+  studio: text('studio'),
   touchedAt: integer('touched_at', { mode: 'timestamp' }),
   createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -126,6 +126,7 @@ export function readApiMenuItemsFromDb(host?: string): MenuItem[] {
     if (row.icon) item.icon = row.icon;
     if (row.access === 'public' || row.access === 'auth') item.access = row.access;
     if (row.hidden) item.hidden = true;
+    if (row.studio) item.studio = row.studio;
     if (row.query) {
       try {
         const parsed = JSON.parse(row.query);

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -148,4 +148,18 @@ describe('readApiMenuItemsFromDb', () => {
     const items = readApiMenuItemsFromDb();
     expect(items.find((i) => i.path === '/map')).toBeUndefined();
   });
+
+  test('exposes populated studio column in /api/menu response', () => {
+    seedMenuItems([sampleSource()]);
+    db.update(menuItems)
+      .set({ studio: 'studio.buildwithoracle.com' })
+      .where(eq(menuItems.path, '/search'))
+      .run();
+
+    const items = readApiMenuItemsFromDb();
+    const search = items.find((i) => i.path === '/search');
+    expect(search?.studio).toBe('studio.buildwithoracle.com');
+    const map = items.find((i) => i.path === '/map');
+    expect(map?.studio).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `studio TEXT NULL` column to `menu_items` (migration 0012).
- Backfills canonical studios for route-seeded rows: `/search` → studio.*, `/feed` → feed.*, `/schedule` → schedule.*, `/map` + `/planets` + `#canvas` → canvas.*.
- `readApiMenuItemsFromDb` now maps `row.studio` → `item.studio`, so the already-declared field in `MenuItemSchema` is no longer silently always-null.

## Why

`MenuItemSchema` declared `studio` but the DB had no column. The cross-origin host-gate in the shared-ui nav resolver relied on this value and was always falling through to the path-only branch — see PR 6 of the menu active-state plan (option A).

## Test plan

- [x] `bun test tests/http/menu/db-seeder.test.ts` — new assertion covers populated studio survives the read path; null rows stay undefined on the item.
- [x] `bun test` — full suite green except a pre-existing unrelated inbox-handoff failure (exists on main prior to this branch).

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle