### PR TITLE
feat(menu): migration 0013 — Forum row to forum.buildwithoracle.com

### DIFF
--- a/src/db/migrations/0013_forum_subdomain.sql
+++ b/src/db/migrations/0013_forum_subdomain.sql
@@ -1,0 +1,10 @@
+-- Migration 0013: Forum row → forum.buildwithoracle.com subdomain
+-- Existing /forum row (seeded via /api/threads route) becomes path='/', studio='forum.*'
+-- Clear parent_id so frontend fallback's Memory ▾ structure owns the hierarchy.
+
+UPDATE menu_items
+   SET path = '/',
+       studio = 'forum.buildwithoracle.com',
+       parent_id = NULL,
+       updated_at = unixepoch()
+ WHERE path = '/forum';

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1779321600000,
       "tag": "0012_menu_studio",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1780000000000,
+      "tag": "0013_forum_subdomain",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -77,7 +77,6 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
  */
 const CHILD_PARENTS: Record<string, string> = {
   '/playground': '#tools',
-  '/forum': '#tools',
   '/plugins': '#tools',
   '/evolution': '#tools',
   '/pulse': '#tools',

--- a/src/routes/menu/__tests__/menu-forum-subdomain.test.ts
+++ b/src/routes/menu/__tests__/menu-forum-subdomain.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Migration 0013: Forum row → forum.buildwithoracle.com subdomain.
+ *
+ * Verifies the raw SQL transformation moves an existing `/forum` row to
+ * path='/', studio='forum.buildwithoracle.com', parent_id=NULL.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { eq, or } from 'drizzle-orm';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { db, menuItems, sqlite } from '../../../db/index.ts';
+import { readApiMenuItemsFromDb } from '../menu.ts';
+
+const MIGRATION_SQL = readFileSync(
+  join(import.meta.dir, '..', '..', '..', 'db', 'migrations', '0013_forum_subdomain.sql'),
+  'utf8',
+);
+
+function applyMigration(): void {
+  for (const stmt of MIGRATION_SQL.split('--> statement-breakpoint')) {
+    const trimmed = stmt.trim();
+    if (!trimmed || trimmed.replace(/--.*$/gm, '').trim() === '') continue;
+    sqlite.exec(trimmed);
+  }
+}
+
+function cleanupForumRows(): void {
+  db
+    .delete(menuItems)
+    .where(
+      or(
+        eq(menuItems.path, '/forum'),
+        eq(menuItems.path, '/'),
+        eq(menuItems.label, '__forum_subdomain_test__'),
+        eq(menuItems.label, '__forum_parent_test__'),
+      ),
+    )
+    .run();
+}
+
+describe('migration 0013 — forum subdomain', () => {
+  beforeEach(() => {
+    cleanupForumRows();
+  });
+
+  afterEach(() => {
+    cleanupForumRows();
+  });
+
+  it('converts /forum row to path=/ with studio=forum.buildwithoracle.com', () => {
+    const now = new Date();
+    const parent = db
+      .insert(menuItems)
+      .values({
+        path: `/__forum_parent_${Date.now()}`,
+        label: '__forum_parent_test__',
+        groupKey: 'main',
+        position: 40,
+        enabled: true,
+        access: 'public',
+        source: 'custom',
+        touchedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+
+    const inserted = db
+      .insert(menuItems)
+      .values({
+        path: '/forum',
+        label: '__forum_subdomain_test__',
+        groupKey: 'main',
+        position: 42,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        studio: null,
+        parentId: parent.id,
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning()
+      .get();
+
+    applyMigration();
+
+    const row = db.select().from(menuItems).where(eq(menuItems.id, inserted.id)).get();
+    expect(row).toBeDefined();
+    expect(row!.path).toBe('/');
+    expect(row!.studio).toBe('forum.buildwithoracle.com');
+    expect(row!.parentId).toBeNull();
+  });
+
+  it('leaves non-forum rows untouched', () => {
+    const now = new Date();
+    const untouchedPath = `/__untouched_${Date.now()}`;
+    try {
+      db
+        .insert(menuItems)
+        .values({
+          path: untouchedPath,
+          label: 'Untouched',
+          groupKey: 'main',
+          position: 500,
+          enabled: true,
+          access: 'public',
+          source: 'custom',
+          studio: 'studio.buildwithoracle.com',
+          touchedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .run();
+
+      applyMigration();
+
+      const row = db.select().from(menuItems).where(eq(menuItems.path, untouchedPath)).get();
+      expect(row?.studio).toBe('studio.buildwithoracle.com');
+      expect(row?.path).toBe(untouchedPath);
+    } finally {
+      db.delete(menuItems).where(eq(menuItems.path, untouchedPath)).run();
+    }
+  });
+
+  it('no row with path=/forum remains after /api/menu read', () => {
+    const now = new Date();
+    db
+      .insert(menuItems)
+      .values({
+        path: '/forum',
+        label: '__forum_subdomain_test__',
+        groupKey: 'main',
+        position: 42,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    applyMigration();
+
+    const items = readApiMenuItemsFromDb();
+    expect(items.some((i) => i.path === '/forum')).toBe(false);
+    const forumSubdomain = items.find(
+      (i) => i.path === '/' && i.studio === 'forum.buildwithoracle.com',
+    );
+    expect(forumSubdomain).toBeDefined();
+  });
+});

--- a/src/routes/menu/__tests__/menu-reorg.test.ts
+++ b/src/routes/menu/__tests__/menu-reorg.test.ts
@@ -11,7 +11,7 @@ import { db, menuItems } from '../../../db/index.ts';
 import { seedMenuItems } from '../../../db/seeders/menu-seeder.ts';
 import { buildTree } from '../admin.ts';
 
-const CHILD_PATHS = ['/playground', '/forum', '/plugins', '/evolution', '/pulse', '/map'] as const;
+const CHILD_PATHS = ['/playground', '/plugins', '/evolution', '/pulse', '/map'] as const;
 const ALL_PATHS = ['#tools', '#canvas', '/planets', ...CHILD_PATHS] as const;
 
 function insertParent(path: string, label: string, position: number): number {
@@ -59,8 +59,8 @@ describe('#958 submenu reorg — seeder reparent post-pass', () => {
     db.delete(menuItems).where(inArray(menuItems.path, ALL_PATHS as unknown as string[])).run();
   });
 
-  it('reparents five Tools children', () => {
-    for (const p of ['/playground', '/forum', '/plugins', '/evolution', '/pulse']) {
+  it('reparents four Tools children', () => {
+    for (const p of ['/playground', '/plugins', '/evolution', '/pulse']) {
       const row = db.select().from(menuItems).where(eq(menuItems.path, p)).get();
       expect(row?.parentId, `parent of ${p}`).toBe(toolsId);
     }
@@ -83,12 +83,12 @@ describe('#958 submenu reorg — seeder reparent post-pass', () => {
     expect(result).toEqual({ inserted: 0, updated: 0, preserved: 0 });
   });
 
-  it('buildTree surfaces Tools w/ 5 children and Canvas w/ 2', () => {
+  it('buildTree surfaces Tools w/ 4 children and Canvas w/ 2', () => {
     const rows = db.select().from(menuItems).where(inArray(menuItems.path, ALL_PATHS as unknown as string[])).all();
     const tree = buildTree(rows);
     const tools = tree.find((n) => n.path === '#tools');
     const canvas = tree.find((n) => n.path === '#canvas');
-    expect(tools?.children.length).toBe(5);
+    expect(tools?.children.length).toBe(4);
     expect(canvas?.children.length).toBe(2);
     expect(canvas?.children.map((c) => c.path).sort()).toEqual(['/map', '/planets']);
   });

--- a/src/routes/menu/menu.ts
+++ b/src/routes/menu/menu.ts
@@ -27,7 +27,7 @@ export const API_TO_STUDIO: ReadonlyArray<readonly [string, string]> = [
   ['/api/search', '/search'],
   ['/api/list', '/feed'],
   ['/api/reflect', '/playground'],
-  ['/api/threads', '/forum'],
+  ['/api/threads', '/'],
   ['/api/traces', '/traces'],
   ['/api/schedule', '/schedule'],
   ['/api/plugins', '/plugins'],


### PR DESCRIPTION
## Summary

Move the Forum row from `/forum` (a Tools submenu child) to its own subdomain at `forum.buildwithoracle.com`, rooted at path `/`.

Part of the forum-extract wave alongside:
- `ui-oracle#60` — frontend DEFAULT_NAV Memory Forum cross-origin, new `apps/forum/` app, legacy `/forum` 302 redirect.
- This PR (arra backend) — DB migration + seeder wiring so the menu API reflects the new subdomain.

## Changes

**Migration 0013** (`src/db/migrations/0013_forum_subdomain.sql`):
```sql
UPDATE menu_items
   SET path = '/',
       studio = 'forum.buildwithoracle.com',
       parent_id = NULL,
       updated_at = unixepoch()
 WHERE path = '/forum';
```
Rewrites any existing `/forum` row in place. `parent_id = NULL` so the frontend fallback's Memory ▾ hierarchy owns the structure going forward.

**Seeder** (`src/db/seeders/menu-seeder.ts`): drop `'/forum': '#tools'` from `CHILD_PARENTS` — Forum is no longer a Tools submenu child.

**Menu route** (`src/routes/menu/menu.ts`): `API_TO_STUDIO` entry `['/api/threads', '/forum']` → `['/api/threads', '/']` so the seeder reconciles labels/groups against the new subdomain row on subsequent boots. (Chose update-to-`/` over delete-entry-entirely — keeps the route → studio mapping alive for seeder idempotence.)

**Tests**:
- `src/routes/menu/__tests__/menu-forum-subdomain.test.ts` (new) — covers migration 0013 behavior: `/forum` → `/` + studio set + parent cleared, non-forum rows untouched, `/api/menu` no longer surfaces a `/forum` path.
- `src/routes/menu/__tests__/menu-reorg.test.ts` — dropped `/forum` from Tools children; updated counts 5 → 4.

## Test output

```
bun test src/routes/menu/__tests__/
 23 pass, 0 fail, 53 expect() calls  (6 files)

bun test (full suite)
 562 pass, 14 skip, 0 fail, 1469 expect() calls  (61 files)
```

## Cross-repo

References `Soul-Brews-Studio/ui-oracle#60`.

Blocks release PR #5 (forum wave bundle).

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle