### PR TITLE
chore: release v26.4.20-alpha.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arra-oracle-v3",
-  "version": "26.4.20-alpha.7",
+  "version": "26.4.20-alpha.9",
   "description": "Arra Oracle - MCP Memory Layer with semantic search, philosophy, and knowledge management",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
Release paired with ui-oracle v26.4.20-alpha.9 bundle (ui-oracle PR #64).

## Changes
- Root `package.json`: `26.4.20-alpha.7` → `26.4.20-alpha.9`

## Bundle
Backend component of the forum subdomain extract:
- PR2b #970 — migration 0013 forum subdomain (menu_items Forum row: path='/' studio='forum.buildwithoracle.com')

## Merge order guard
Merge **LAST**, after: Step 0 DNS → PR1 (ui-oracle #63) → PR2 (ui-oracle #61) → PR2b (arra #970) → PR4 (ui-oracle #62) → this PR + ui-oracle PR #64 → final deploy sweep via `bun run deploy:studio && deploy:vector && deploy:canvas && deploy:schedule && deploy:feed && deploy:forum` on ui-oracle.

## CalVer note
`alpha.9` = hour 09 UTC+7 (20 April 2026).

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>