### PR TITLE
fix(menu): seeder lookup keys on (path, studio) composite (#65)

### DIFF
--- a/src/db/migrations/0014_menu_path_studio_composite.sql
+++ b/src/db/migrations/0014_menu_path_studio_composite.sql
@@ -1,0 +1,12 @@
+-- Migration 0014: menu_items unique key on (path, studio) composite.
+-- After migration 0013 extracted Forum to studio='forum.buildwithoracle.com',
+-- further subdomain extracts (Feed, Canvas, Schedule) will also map to path='/'.
+-- The old UNIQUE(path) index would reject those rows; replace with composite.
+-- COALESCE(studio, '') so NULL studios collide with each other — preserves the
+-- "duplicate path" guarantee for legacy/route-seeded rows where studio is null.
+
+DROP INDEX IF EXISTS `menu_items_path_unique`;
+--> statement-breakpoint
+DROP INDEX IF EXISTS `menu_items_path_studio_unique`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `menu_items_path_studio_unique` ON `menu_items` (`path`, COALESCE(`studio`, ''));

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780000000000,
       "tag": "0013_forum_subdomain",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1780012800000,
+      "tag": "0014_menu_path_studio_composite",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -296,7 +296,7 @@ export const settings = sqliteTable('settings', {
 
 export const menuItems = sqliteTable('menu_items', {
   id: integer('id').primaryKey({ autoIncrement: true }),
-  path: text('path').notNull().unique(),
+  path: text('path').notNull(),
   label: text('label').notNull(),
   groupKey: text('group_key').notNull(),
   parentId: integer('parent_id').references((): AnySQLiteColumn => menuItems.id, { onDelete: 'cascade' }),

--- a/src/db/seeders/menu-seeder.ts
+++ b/src/db/seeders/menu-seeder.ts
@@ -8,7 +8,7 @@
  *   - touchedAt != null        → PRESERVE (user edit wins); log drift
  */
 
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import type { BunSQLiteDatabase } from 'drizzle-orm/bun-sqlite';
 import * as schema from '../schema.ts';
 import { db as defaultDb } from '../index.ts';
@@ -25,6 +25,7 @@ export interface RouteMenuRow {
   position: number;
   access: string;
   icon?: string | null;
+  studio?: string | null; // host subdomain (e.g. feed.buildwithoracle.com); null = legacy studio.*
 }
 
 function studioPathFor(apiPath: string): string | null {
@@ -63,6 +64,7 @@ export function collectRouteMenuRows(sources: HasRoutes[]): RouteMenuRow[] {
         position: order,
         access: menu.access ?? 'public',
         icon: menu.icon ?? null,
+        studio: null,
       });
     }
   }
@@ -104,7 +106,14 @@ export function seedMenuItems(
       const existing = tx
         .select()
         .from(schema.menuItems)
-        .where(eq(schema.menuItems.path, row.path))
+        .where(
+          and(
+            eq(schema.menuItems.path, row.path),
+            row.studio == null
+              ? isNull(schema.menuItems.studio)
+              : eq(schema.menuItems.studio, row.studio),
+          ),
+        )
         .get();
 
       if (!existing) {
@@ -117,6 +126,7 @@ export function seedMenuItems(
             access: row.access,
             source: 'route',
             icon: row.icon ?? null,
+            studio: row.studio ?? null,
             enabled: true,
             touchedAt: null,
             createdAt: now,
@@ -158,13 +168,13 @@ export function seedMenuItems(
       const parent = tx
         .select()
         .from(schema.menuItems)
-        .where(eq(schema.menuItems.path, parentPath))
+        .where(and(eq(schema.menuItems.path, parentPath), isNull(schema.menuItems.studio)))
         .get();
       if (!parent) continue;
       const child = tx
         .select()
         .from(schema.menuItems)
-        .where(eq(schema.menuItems.path, childPath))
+        .where(and(eq(schema.menuItems.path, childPath), isNull(schema.menuItems.studio)))
         .get();
       if (!child || child.parentId === parent.id) continue;
       tx.update(schema.menuItems)

--- a/src/routes/menu/__tests__/menu-seeder-composite.test.ts
+++ b/src/routes/menu/__tests__/menu-seeder-composite.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Issue #65: menu-seeder must key existing-row lookup on (path, studio)
+ * composite, not path alone. Once subdomain extracts (Forum done, Feed/
+ * Canvas/Schedule planned) all share path='/', a path-only lookup collides.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { Elysia } from 'elysia';
+import { and, eq, isNull, or } from 'drizzle-orm';
+import { db, menuItems } from '../../../db/index.ts';
+import { seedMenuItems } from '../../../db/seeders/menu-seeder.ts';
+
+const FORUM_STUDIO = 'forum.buildwithoracle.com';
+const FEED_STUDIO = 'feed.buildwithoracle.com';
+
+function cleanupRows(): void {
+  db
+    .delete(menuItems)
+    .where(
+      or(
+        eq(menuItems.label, '__composite_forum__'),
+        eq(menuItems.label, '__composite_feed__'),
+        eq(menuItems.label, '__composite_route__'),
+      ),
+    )
+    .run();
+  db
+    .delete(menuItems)
+    .where(and(eq(menuItems.path, '/'), isNull(menuItems.studio)))
+    .run();
+}
+
+function routeSource() {
+  return new Elysia({ prefix: '/api' }).get('/threads', () => ({}), {
+    detail: {
+      menu: { group: 'main', order: 40, label: '__composite_route__' },
+      summary: 'Threads',
+    },
+  });
+}
+
+describe('menu-seeder — composite (path, studio) lookup (#65)', () => {
+  beforeEach(() => {
+    cleanupRows();
+  });
+
+  afterEach(() => {
+    cleanupRows();
+  });
+
+  it('two rows sharing path=/ with different studio do not collide', () => {
+    const now = new Date();
+    db.insert(menuItems)
+      .values({
+        path: '/',
+        studio: FORUM_STUDIO,
+        label: '__composite_forum__',
+        groupKey: 'main',
+        position: 42,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(menuItems)
+      .values({
+        path: '/',
+        studio: FEED_STUDIO,
+        label: '__composite_feed__',
+        groupKey: 'main',
+        position: 30,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    const rows = db
+      .select()
+      .from(menuItems)
+      .where(eq(menuItems.path, '/'))
+      .all();
+    const studios = rows.map((r) => r.studio).sort();
+    expect(studios).toEqual([FEED_STUDIO, FORUM_STUDIO]);
+  });
+
+  it('seeder updates only the (path, studio) match — leaves sibling rows untouched', () => {
+    const now = new Date();
+    // Simulate post-0013 forum row (path=/, studio=forum.*) + hypothetical
+    // future feed extract row (path=/, studio=feed.*). Both are source=route,
+    // untouched — the current reseed would previously clobber whichever
+    // matched `eq(path, '/')` first.
+    db.insert(menuItems)
+      .values({
+        path: '/',
+        studio: FORUM_STUDIO,
+        label: '__composite_forum__',
+        groupKey: 'main',
+        position: 42,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    db.insert(menuItems)
+      .values({
+        path: '/',
+        studio: FEED_STUDIO,
+        label: '__composite_feed__',
+        groupKey: 'main',
+        position: 30,
+        enabled: true,
+        access: 'public',
+        source: 'route',
+        touchedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    seedMenuItems([routeSource()]);
+
+    const forum = db
+      .select()
+      .from(menuItems)
+      .where(and(eq(menuItems.path, '/'), eq(menuItems.studio, FORUM_STUDIO)))
+      .get();
+    const feed = db
+      .select()
+      .from(menuItems)
+      .where(and(eq(menuItems.path, '/'), eq(menuItems.studio, FEED_STUDIO)))
+      .get();
+
+    // Studio-bearing rows untouched — seeder only matches isNull(studio) routes.
+    expect(forum?.label).toBe('__composite_forum__');
+    expect(forum?.position).toBe(42);
+    expect(feed?.label).toBe('__composite_feed__');
+    expect(feed?.position).toBe(30);
+
+    // The route (/api/threads → studio path '/') produces studio=null and
+    // does NOT collide with the subdomain rows — it inserts a fresh row.
+    const routeRow = db
+      .select()
+      .from(menuItems)
+      .where(and(eq(menuItems.path, '/'), isNull(menuItems.studio)))
+      .get();
+    expect(routeRow?.label).toBe('__composite_route__');
+  });
+
+  it('reseed is idempotent for null-studio route rows at path=/', () => {
+    seedMenuItems([routeSource()]);
+    const first = db
+      .select()
+      .from(menuItems)
+      .where(and(eq(menuItems.path, '/'), isNull(menuItems.studio)))
+      .get();
+    expect(first?.label).toBe('__composite_route__');
+
+    const second = seedMenuItems([routeSource()]);
+    expect(second.inserted).toBe(0);
+    expect(second.updated).toBe(0);
+
+    // Still exactly one null-studio row at path=/.
+    const rows = db
+      .select()
+      .from(menuItems)
+      .where(and(eq(menuItems.path, '/'), isNull(menuItems.studio)))
+      .all();
+    expect(rows).toHaveLength(1);
+  });
+});

--- a/tests/http/menu/db-seeder.test.ts
+++ b/tests/http/menu/db-seeder.test.ts
@@ -39,9 +39,9 @@ describe('collectRouteMenuRows', () => {
   test('maps api paths to studio paths + menu meta', () => {
     const rows = collectRouteMenuRows([sampleSource()]);
     expect(rows).toEqual([
-      { path: '/search', label: 'Search', groupKey: 'main', position: 10, access: 'public', icon: null },
-      { path: '/traces', label: 'Traces', groupKey: 'main', position: 40, access: 'public', icon: null },
-      { path: '/map', label: 'Map', groupKey: 'tools', position: 20, access: 'public', icon: null },
+      { path: '/search', label: 'Search', groupKey: 'main', position: 10, access: 'public', icon: null, studio: null },
+      { path: '/traces', label: 'Traces', groupKey: 'main', position: 40, access: 'public', icon: null, studio: null },
+      { path: '/map', label: 'Map', groupKey: 'tools', position: 20, access: 'public', icon: null, studio: null },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- Seeder's existing-row lookup now matches on composite `(path, studio)` instead of `path` alone, with `isNull(studio)` for null-studio route rows.
- `RouteMenuRow` gains a `studio: string | null` field (always `null` for route-seeded rows — routes don't declare a studio host).
- Migration `0014_menu_path_studio_composite.sql` drops `UNIQUE(path)` and adds `UNIQUE(path, COALESCE(studio, ''))` so subdomain-extracted rows can coexist at `path='/'` while null-studio duplicates still 409.
- `CHILD_PARENTS` parent/child lookups also filter `isNull(studio)` for consistency — those sentinel rows (`#tools`, `#canvas`) are null-studio by design.

## Why

After migration 0013 moved Forum to `path='/', studio='forum.buildwithoracle.com'`, and with Feed/Canvas/Schedule subdomain extracts on deck, `.where(eq(path, '/')).get()` would silently match the wrong row and corrupt it on every reseed.

## Test plan

- [x] `bun test` — 565 pass, 14 skip, 0 fail
- [x] New test `src/routes/menu/__tests__/menu-seeder-composite.test.ts` — 3 tests, 10 expects
  - Two rows sharing `path='/'` with different studios coexist
  - Seeder leaves studio-bearing rows untouched while inserting its null-studio route row
  - Reseed is idempotent for null-studio route rows

## Closes

#65

🤖 ตอบโดย arra-oracle-v3 จาก [Nat] → arra-oracle-v3-oracle