### PR TITLE
fix: shebang, install.sh URL, Bun.serve wrapper (#1012, #1013, #1014)

### DIFF
--- a/bin/arra.ts
+++ b/bin/arra.ts
@@ -25,7 +25,11 @@ if (portIdx !== -1) {
   process.env.ORACLE_PORT = val;
 }
 
-const port = process.env.ORACLE_PORT || "47778";
-console.log(`🔮 Arra Oracle HTTP server → http://localhost:${port}`);
-
-await import("../src/server.ts");
+// Load server module (registers routes + plugins via Elysia setup).
+// Bun's `export default { port, fetch }` auto-server pattern only fires when
+// the file is the entry script. When bin/arra.ts wraps server.ts via
+// `await import()`, the export becomes plain data and no listener is bound.
+// Call Bun.serve() explicitly so the wrapper actually starts a server.
+const { default: appSpec } = await import("../src/server.ts");
+const server = Bun.serve(appSpec);
+console.log(`🔮 Arra Oracle HTTP server → http://localhost:${server.port}`);

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,8 +10,8 @@
 set -e
 
 INSTALL_DIR="${ORACLE_INSTALL_DIR:-$HOME/.local/share/arra-oracle-v2}"
-REPO_URL="https://github.com/Soul-Brews-Studio/arra-oracle-v2.git"
-REPO_API="https://api.github.com/repos/Soul-Brews-Studio/arra-oracle-v2"
+REPO_URL="https://github.com/Soul-Brews-Studio/arra-oracle-v3.git"
+REPO_API="https://api.github.com/repos/Soul-Brews-Studio/arra-oracle-v3"
 
 echo "🔮 Arra Oracle Installer"
 echo "======================"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env bun
 /**
  * Arra Oracle MCP Server
  *


### PR DESCRIPTION
## Summary

Three small fixes from the m5-oracle install dogfooding session on 2026-04-25.

- **#1012** — `src/index.ts` was the only bin missing `#!/usr/bin/env bun`. Added.
- **#1013** — `scripts/install.sh` had stale URLs pointing at `arra-oracle-v2`. Updated to `arra-oracle-v3`.
- **#1014** — `bin/arra.ts` wrapped `src/server.ts` via `await import()`, which defeats Bun's `export default { port, fetch }` auto-server pattern. Server logged "running!" without binding port. Now calls `Bun.serve(appSpec)` explicitly.

## Test plan

- [x] `bun src/index.ts` — MCP handshake still works (responds to `initialize`)
- [ ] `bun bin/arra.ts` — HTTP server actually binds `:47778` (post-merge verify)
- [ ] `pm2 start bun --interpreter none -- bin/arra.ts` — long-running supervised process
- [ ] `bunx --bun arra-oracle-v2@github:...` — picks the right bin (validates #1012)
- [ ] `curl install.sh | bash` — clones from v3 repo (validates #1013)

Closes #1012
Closes #1013
Closes #1014

---

🤖 ตอบโดย maw-m5 จาก Nat → maw-m5-oracle