### PR TITLE
fix: cosine distance + bge-m3 instruction prefix

### DIFF
--- a/src/vector/adapters/cloudflare-vectorize.ts
+++ b/src/vector/adapters/cloudflare-vectorize.ts
@@ -11,7 +11,7 @@
  * Model: @cf/baai/bge-m3 (multilingual, 1024 dimensions)
  */
 
-import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider } from '../types.ts';
+import type { VectorStoreAdapter, VectorDocument, VectorQueryResult, EmbeddingProvider, EmbedType } from '../types.ts';
 
 const CF_MODEL = '@cf/baai/bge-m3';
 const CF_DIMENSIONS = 1024;
@@ -38,7 +38,7 @@ export class CloudflareAIEmbeddings implements EmbeddingProvider {
     }
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
     if (!texts.length) return [];
 
     const allEmbeddings: number[][] = [];
@@ -194,7 +194,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
     if (docs.length === 0) return;
 
     const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts);
+    const embeddings = await this.embedder.embed(texts, 'passage');
 
     // Vectorize upsert in batches (max 1000 per call)
     const UPSERT_BATCH = 1000;
@@ -229,7 +229,7 @@ export class CloudflareVectorizeAdapter implements VectorStoreAdapter {
   }
 
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
-    const [queryEmbedding] = await this.embedder.embed([text]);
+    const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
     const body: any = {
       vector: queryEmbedding,

--- a/src/vector/adapters/lancedb.ts
+++ b/src/vector/adapters/lancedb.ts
@@ -73,7 +73,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     if (!this.table) await this.ensureCollection();
 
     const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts);
+    const embeddings = await this.embedder.embed(texts, 'passage');
 
     const rows = docs.map((doc, i) => ({
       id: doc.id,
@@ -89,11 +89,11 @@ export class LanceDBAdapter implements VectorStoreAdapter {
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
     if (!this.table) await this.ensureCollection();
 
-    const [queryEmbedding] = await this.embedder.embed([text]);
+    const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
     // Fetch extra results if filtering in JS (metadata is stored as string, not binary)
     const fetchLimit = where ? limit * 3 : limit;
-    const results = await this.table.search(queryEmbedding).limit(fetchLimit).toArray();
+    const results = await this.table.search(queryEmbedding).distanceType('cosine').limit(fetchLimit).toArray();
 
     // Filter metadata in JavaScript (LanceDB json_extract requires LargeBinary, not Utf8)
     let filtered = results;
@@ -122,7 +122,7 @@ export class LanceDBAdapter implements VectorStoreAdapter {
     }
 
     const vector = Array.from(rows[0].vector);
-    const results = await this.table.search(vector).limit(nResults + 1).toArray();
+    const results = await this.table.search(vector).distanceType('cosine').limit(nResults + 1).toArray();
 
     const filtered = results.filter((r: any) => r.id !== id).slice(0, nResults);
 

--- a/src/vector/adapters/qdrant.ts
+++ b/src/vector/adapters/qdrant.ts
@@ -76,7 +76,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
     if (!this.client) throw new Error('Qdrant not connected');
 
     const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts);
+    const embeddings = await this.embedder.embed(texts, 'passage');
 
     const points = docs.map((doc, i) => ({
       id: this.hashId(doc.id),
@@ -95,7 +95,7 @@ export class QdrantAdapter implements VectorStoreAdapter {
   async query(text: string, limit: number = 10, where?: Record<string, any>): Promise<VectorQueryResult> {
     if (!this.client) throw new Error('Qdrant not connected');
 
-    const [queryEmbedding] = await this.embedder.embed([text]);
+    const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
     const filter = where ? {
       must: Object.entries(where).map(([key, value]) => ({

--- a/src/vector/adapters/sqlite-vec.ts
+++ b/src/vector/adapters/sqlite-vec.ts
@@ -126,7 +126,7 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
 
     // Generate embeddings for all documents
     const texts = docs.map(d => d.document);
-    const embeddings = await this.embedder.embed(texts);
+    const embeddings = await this.embedder.embed(texts, 'passage');
 
     const insertMeta = this.db.prepare(`
       INSERT OR REPLACE INTO ${this.collectionName}_meta (id, document, metadata)
@@ -158,7 +158,7 @@ export class SqliteVecAdapter implements VectorStoreAdapter {
     if (!this.db) throw new Error('sqlite-vec not connected');
 
     // Generate query embedding
-    const [queryEmbedding] = await this.embedder.embed([text]);
+    const [queryEmbedding] = await this.embedder.embed([text], 'query');
 
     // When filtering, fetch more results since we filter in JS
     const fetchLimit = where ? limit * 3 : limit;

--- a/src/vector/embeddings.ts
+++ b/src/vector/embeddings.ts
@@ -5,7 +5,7 @@
  * ChromaDB handles embeddings internally; other stores need these.
  */
 
-import type { EmbeddingProvider, EmbeddingProviderType } from './types.ts';
+import type { EmbeddingProvider, EmbeddingProviderType, EmbedType } from './types.ts';
 
 /**
  * Placeholder for ChromaDB's internal embeddings.
@@ -15,7 +15,7 @@ export class ChromaDBInternalEmbeddings implements EmbeddingProvider {
   readonly name = 'chromadb-internal';
   readonly dimensions = 384; // all-MiniLM-L6-v2 default
 
-  async embed(_texts: string[]): Promise<number[][]> {
+  async embed(_texts: string[], _type?: EmbedType): Promise<number[][]> {
     throw new Error('ChromaDB handles embeddings internally. Use addDocuments() directly.');
   }
 }
@@ -44,12 +44,19 @@ export class OllamaEmbeddings implements EmbeddingProvider {
     this.dimensions = KNOWN_DIMS[this.model] || 768;
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], type?: EmbedType): Promise<number[][]> {
     const embeddings: number[][] = [];
 
     for (const text of texts) {
       // Truncate to ~2000 chars — Thai text uses 2-3x more tokens than English
-      const truncated = text.length > 2000 ? text.slice(0, 2000) : text;
+      let truncated = text.length > 2000 ? text.slice(0, 2000) : text;
+
+      // bge-m3 needs instruction prefixes for accurate retrieval
+      if (this.model.includes('bge') && type === 'query') {
+        truncated = `query: ${truncated}`;
+      } else if (this.model.includes('bge') && type === 'passage') {
+        truncated = `passage: ${truncated}`;
+      }
       const response = await fetch(`${this.baseUrl}/api/embeddings`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -94,7 +101,7 @@ export class OpenAIEmbeddings implements EmbeddingProvider {
     }
   }
 
-  async embed(texts: string[]): Promise<number[][]> {
+  async embed(texts: string[], _type?: EmbedType): Promise<number[][]> {
     const response = await fetch('https://api.openai.com/v1/embeddings', {
       method: 'POST',
       headers: {

--- a/src/vector/types.ts
+++ b/src/vector/types.ts
@@ -36,6 +36,8 @@ export interface VectorStoreAdapter {
   getAllEmbeddings?(limit?: number): Promise<{ ids: string[]; embeddings: number[][]; metadatas: any[] }>;
 }
 
+export type EmbedType = 'query' | 'passage';
+
 /**
  * Embedding provider interface.
  * Separated from storage because ChromaDB handles embeddings internally,
@@ -44,7 +46,7 @@ export interface VectorStoreAdapter {
 export interface EmbeddingProvider {
   readonly name: string;
   readonly dimensions: number;
-  embed(texts: string[]): Promise<number[][]>;
+  embed(texts: string[], type?: EmbedType): Promise<number[][]>;
 }
 
 export type VectorDBType = 'chroma' | 'sqlite-vec' | 'lancedb' | 'qdrant' | 'cloudflare-vectorize';


### PR DESCRIPTION
## Summary
- **Bug 1 (P0)**: Changed LanceDB default distance from L2 to cosine — bge-m3 outputs unnormalized vectors (~magnitude 26), L2 causes magnitude-mismatch noise
- **Bug 2 (P1)**: Added instruction prefix for bge-m3 — `"query: "` for search, `"passage: "` for indexing. Without prefix, query and doc embeddings cluster together

## Changes (6 files)
- `types.ts`: Added `EmbedType` union type, updated `EmbeddingProvider.embed()` signature
- `embeddings.ts`: Prefix logic for bge-family models
- `lancedb.ts`: `.distanceType('cosine')` + pass embed type
- `qdrant.ts`, `sqlite-vec.ts`, `cloudflare-vectorize.ts`: Pass embed type

Closes #1059

## Test plan
- [ ] Run `bun test` for vector adapter tests
- [ ] Reindex with `bun src/scripts/index-model.ts bge-m3` and verify cosine distances
- [ ] Compare search results before/after via Vector Playground

🤖 ตอบโดย arra-mcp-installation-guide จาก [Nat] → arra-mcp-installation-guide-oracle