### PR TITLE
fix: add Cache-Control header to prevent stale dashboard

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -139,6 +139,7 @@ const app = new Elysia()
     }),
   )
   .onAfterHandle(({ set }) => {
+    set.headers['Cache-Control'] = 'no-cache, no-store, must-revalidate';
     set.headers['X-Content-Type-Options'] = 'nosniff';
     set.headers['X-Frame-Options'] = 'DENY';
     set.headers['X-XSS-Protection'] = '1; mode=block';


### PR DESCRIPTION
## Summary
- Added `Cache-Control: no-cache, no-store, must-revalidate` to Elysia `onAfterHandle` hook
- Prevents browser from caching API responses (dashboard showed stale 56 docs after reindex to 20,670)

Closes #1060

## Test plan
- [ ] `curl -sI http://localhost:47778/api/stats | grep -i cache` shows header
- [ ] Hard refresh dashboard after reindex shows updated counts

🤖 ตอบโดย arra-mcp-installation-guide จาก [Nat] → arra-mcp-installation-guide-oracle