### PR TITLE
feat(indexer): interactive indexer API endpoints

### DIFF
--- a/src/routes/indexer/config.ts
+++ b/src/routes/indexer/config.ts
@@ -1,0 +1,34 @@
+import { Elysia } from 'elysia';
+import { getEmbeddingModels } from '../../vector/factory.ts';
+
+export const configEndpoint = new Elysia().get('/indexer/config', async () => {
+  const models = getEmbeddingModels();
+
+  const modelList = Object.entries(models).map(([key, m]) => ({
+    key,
+    model: m.model,
+    collection: m.collection,
+    dims: key === 'nomic' ? 768 : key === 'bge-m3' ? 1024 : 4096,
+    speed: key === 'nomic' ? '~100 doc/s' : key === 'bge-m3' ? '~50 doc/s' : '~30 doc/s',
+  }));
+
+  const adapters = ['lancedb', 'sqlite-vec', 'chroma', 'qdrant', 'cloudflare-vectorize'];
+  const currentAdapter = process.env.ORACLE_VECTOR_DB || 'lancedb';
+
+  let ollamaModels: string[] = [];
+  try {
+    const res = await fetch('http://localhost:11434/api/tags');
+    if (res.ok) {
+      const data = await res.json() as { models?: Array<{ name: string }> };
+      ollamaModels = (data.models || []).map(m => m.name);
+    }
+  } catch {}
+
+  return { adapters, models: modelList, ollamaModels, currentAdapter };
+}, {
+  detail: {
+    tags: ['indexer'],
+    menu: { group: 'tools', order: 110 },
+    summary: 'Indexer configuration — adapters, models, Ollama status',
+  },
+});

--- a/src/routes/indexer/index.ts
+++ b/src/routes/indexer/index.ts
@@ -1,0 +1,13 @@
+import { Elysia } from 'elysia';
+import { configEndpoint } from './config.ts';
+import { scanEndpoint } from './scan.ts';
+import { startEndpoint } from './start.ts';
+import { progressEndpoint } from './progress.ts';
+import { stopEndpoint } from './stop.ts';
+
+export const indexerRoutes = new Elysia({ prefix: '/api' })
+  .use(configEndpoint)
+  .use(scanEndpoint)
+  .use(startEndpoint)
+  .use(progressEndpoint)
+  .use(stopEndpoint);

--- a/src/routes/indexer/progress.ts
+++ b/src/routes/indexer/progress.ts
@@ -1,0 +1,85 @@
+import { Elysia } from 'elysia';
+import { DB_PATH } from '../../config.ts';
+import { Database } from 'bun:sqlite';
+
+export const progressEndpoint = new Elysia().get('/indexer/progress', async ({ set }) => {
+  set.headers['Content-Type'] = 'text/event-stream';
+  set.headers['Cache-Control'] = 'no-cache';
+  set.headers['Connection'] = 'keep-alive';
+
+  const encoder = new TextEncoder();
+
+  return new Response(
+    new ReadableStream({
+      async start(controller) {
+        const sqlite = new Database(DB_PATH, { readonly: true });
+        let done = false;
+
+        while (!done) {
+          try {
+            const row = sqlite.prepare(
+              'SELECT is_indexing, progress_current, progress_total, error, started_at, completed_at FROM indexing_status WHERE id = 1'
+            ).get() as {
+              is_indexing: number;
+              progress_current: number;
+              progress_total: number;
+              error: string | null;
+              started_at: number | null;
+              completed_at: number | null;
+            } | null;
+
+            if (!row) {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ status: 'idle', current: 0, total: 0 })}\n\n`));
+              done = true;
+              break;
+            }
+
+            const elapsed = row.started_at ? (Date.now() - row.started_at) / 1000 : 0;
+            const docsPerSec = elapsed > 0 && row.progress_current > 0
+              ? (row.progress_current / elapsed).toFixed(1)
+              : '0';
+            const remaining = row.progress_total - row.progress_current;
+            const eta = Number(docsPerSec) > 0 ? Math.ceil(remaining / Number(docsPerSec)) : 0;
+
+            const status = row.error
+              ? 'error'
+              : row.is_indexing
+                ? 'indexing'
+                : row.progress_current >= row.progress_total && row.progress_total > 0
+                  ? 'completed'
+                  : 'idle';
+
+            const payload = {
+              status,
+              current: row.progress_current,
+              total: row.progress_total,
+              docsPerSec,
+              eta,
+              error: row.error,
+            };
+
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+
+            if (status === 'completed' || status === 'error' || status === 'idle') {
+              done = true;
+              break;
+            }
+
+            await new Promise(r => setTimeout(r, 500));
+          } catch {
+            done = true;
+          }
+        }
+
+        sqlite.close();
+        controller.close();
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' } }
+  );
+}, {
+  detail: {
+    tags: ['indexer'],
+    summary: 'SSE stream of indexing progress',
+  },
+});

--- a/src/routes/indexer/scan.ts
+++ b/src/routes/indexer/scan.ts
@@ -1,0 +1,52 @@
+import { Elysia, t } from 'elysia';
+import fs from 'fs';
+import path from 'path';
+import { getAllMarkdownFiles } from '../../indexer/collectors.ts';
+
+export const scanEndpoint = new Elysia().post('/indexer/scan', async ({ body }) => {
+  const { sourcePath, types } = body;
+
+  if (!fs.existsSync(sourcePath)) {
+    return { error: `Path not found: ${sourcePath}`, files: [], total: 0, byType: {} };
+  }
+
+  const allFiles = getAllMarkdownFiles(sourcePath);
+
+  const files = allFiles.map(filePath => {
+    const stat = fs.statSync(filePath);
+    const rel = path.relative(sourcePath, filePath);
+
+    let type = 'unknown';
+    if (rel.includes('learnings') || rel.includes('learning')) type = 'learning';
+    else if (rel.includes('retrospectives') || rel.includes('retro')) type = 'retro';
+    else if (rel.includes('resonance') || rel.includes('principle')) type = 'principle';
+
+    return {
+      path: filePath,
+      relativePath: rel,
+      size: stat.size,
+      type,
+      modified: stat.mtimeMs,
+    };
+  });
+
+  const filtered = types && types.length > 0
+    ? files.filter(f => types.includes(f.type))
+    : files;
+
+  const byType: Record<string, number> = {};
+  for (const f of filtered) {
+    byType[f.type] = (byType[f.type] || 0) + 1;
+  }
+
+  return { files: filtered, total: filtered.length, byType };
+}, {
+  body: t.Object({
+    sourcePath: t.String(),
+    types: t.Optional(t.Array(t.String())),
+  }),
+  detail: {
+    tags: ['indexer'],
+    summary: 'Scan directory for .md files',
+  },
+});

--- a/src/routes/indexer/start.ts
+++ b/src/routes/indexer/start.ts
@@ -1,0 +1,108 @@
+import { Elysia, t } from 'elysia';
+import { createVectorStore, getEmbeddingModels } from '../../vector/factory.ts';
+import { createDatabase } from '../../db/index.ts';
+import { setIndexingStatus } from '../../indexer/status.ts';
+import { DB_PATH, REPO_ROOT } from '../../config.ts';
+import type { IndexerConfig } from '../../types.ts';
+
+let abortFlag = false;
+export function getAbortFlag() { return abortFlag; }
+export function setAbortFlag(v: boolean) { abortFlag = v; }
+
+export const startEndpoint = new Elysia().post('/indexer/start', async ({ body }) => {
+  const { model, sourcePath, batchSize } = body;
+
+  const models = getEmbeddingModels();
+  const key = model && models[model] ? model : 'nomic';
+  const preset = models[key];
+  const batch = batchSize || (key === 'nomic' ? 100 : 50);
+
+  const { db, sqlite } = createDatabase(DB_PATH);
+  const config: IndexerConfig = {
+    repoRoot: sourcePath || REPO_ROOT,
+    dbPath: DB_PATH,
+    chromaPath: '',
+    sourcePaths: {
+      resonance: `${sourcePath || REPO_ROOT}/memory/resonance`,
+      learnings: `${sourcePath || REPO_ROOT}/memory/learnings`,
+      retrospectives: `${sourcePath || REPO_ROOT}/memory/retrospectives`,
+    },
+  };
+
+  const store = createVectorStore({
+    type: 'lancedb',
+    collectionName: preset.collection,
+    embeddingProvider: 'ollama',
+    embeddingModel: preset.model,
+    ...(preset.dataPath && { dataPath: preset.dataPath }),
+  });
+
+  abortFlag = false;
+
+  const jobId = `idx-${Date.now()}`;
+
+  // Run indexing in background
+  (async () => {
+    try {
+      await store.connect();
+      try { await store.deleteCollection(); } catch {}
+      await store.ensureCollection();
+
+      const rows = sqlite.prepare(`
+        SELECT d.id, d.type, GROUP_CONCAT(f.content, '\n') as content, d.source_file, d.concepts, d.project, d.created_at
+        FROM oracle_documents d
+        JOIN oracle_fts f ON d.id = f.id
+        GROUP BY d.id
+        ORDER BY d.created_at DESC
+      `).all() as Array<{
+        id: string; type: string; content: string;
+        source_file: string; concepts: string; project: string | null; created_at: string;
+      }>;
+
+      const total = rows.length;
+      setIndexingStatus(sqlite, config, true, 0, total);
+
+      for (let i = 0; i < rows.length; i += batch) {
+        if (abortFlag) {
+          setIndexingStatus(sqlite, config, false, i, total, 'Cancelled by user');
+          break;
+        }
+
+        const batchRows = rows.slice(i, i + batch);
+        const docs = batchRows.map(row => ({
+          id: row.id,
+          document: row.content,
+          metadata: {
+            type: row.type,
+            source_file: row.source_file,
+            concepts: row.concepts,
+            ...(row.project && { project: row.project }),
+          },
+        }));
+
+        await store.addDocuments(docs);
+        setIndexingStatus(sqlite, config, true, i + batchRows.length, total);
+      }
+
+      if (!abortFlag) {
+        setIndexingStatus(sqlite, config, false, rows.length, rows.length);
+      }
+      await store.close();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setIndexingStatus(sqlite, config, false, 0, 0, msg);
+    }
+  })();
+
+  return { jobId, status: 'started', model: key, batchSize: batch };
+}, {
+  body: t.Object({
+    model: t.Optional(t.String()),
+    sourcePath: t.Optional(t.String()),
+    batchSize: t.Optional(t.Number()),
+  }),
+  detail: {
+    tags: ['indexer'],
+    summary: 'Start vector indexing job',
+  },
+});

--- a/src/routes/indexer/stop.ts
+++ b/src/routes/indexer/stop.ts
@@ -1,0 +1,12 @@
+import { Elysia } from 'elysia';
+import { setAbortFlag } from './start.ts';
+
+export const stopEndpoint = new Elysia().post('/indexer/stop', () => {
+  setAbortFlag(true);
+  return { stopped: true };
+}, {
+  detail: {
+    tags: ['indexer'],
+    summary: 'Stop running indexer job',
+  },
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,6 +41,7 @@ import { pluginsRouter } from './routes/plugins/index.ts';
 import { oraclenetRoutes } from './routes/oraclenet/index.ts';
 import { sessionsRoutes } from './routes/sessions/index.ts';
 import { vaultRoutes } from './routes/vault/index.ts';
+import { indexerRoutes } from './routes/indexer/index.ts';
 import { createMenuRoutes } from './routes/menu/index.ts';
 
 import pkg from '../package.json' with { type: 'json' };
@@ -183,6 +184,7 @@ const apiModules = [
   oraclenetRoutes,
   sessionsRoutes,
   vaultRoutes,
+  indexerRoutes,
 ];
 
 try {


### PR DESCRIPTION
## Summary
- 5 new API endpoints for the interactive indexer app (`/api/indexer/*`)
- `GET /config` — returns available adapters, models, Ollama status
- `POST /scan` — scans directory for .md files with type filtering
- `POST /start` — starts async vector indexing with configurable model/batch
- `GET /progress` — SSE stream with real-time progress (docs/sec, ETA)
- `POST /stop` — cancels running indexer via abort flag
- Reuses existing `indexer/collectors.ts`, `vector/factory.ts`, `indexer/status.ts`

## Test plan
- [x] `curl /api/indexer/config` returns adapters + models + Ollama list
- [x] `curl -X POST /api/indexer/scan` scans vault directory
- [x] `curl /api/indexer/progress` returns SSE stream
- [x] TypeScript compiles with zero errors
- [x] Frontend UI connects and populates dropdowns

🤖 ตอบโดย arra-mcp-installation-guide จาก [Nat] → arra-mcp-installation-guide-oracle