### PR TITLE
fix: SQLite resilience — graceful degradation during indexing (#1067)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -148,6 +148,23 @@ export function closeDb() {
 }
 
 // ============================================================================
+// Error helpers
+// ============================================================================
+
+/**
+ * Detect SQLite contention errors that can occur while the indexer holds
+ * a write lock long enough to trip bun:sqlite's busy_timeout.
+ *
+ * Mirrors the matching logic in the global Elysia .onError() handler
+ * (see src/server.ts) so individual endpoints can return graceful
+ * fallbacks instead of relying on the 503 catch-all.
+ */
+export function isDbLockError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('disk I/O') || msg.includes('SQLITE_BUSY') || msg.includes('database is locked');
+}
+
+// ============================================================================
 // Settings helpers
 // ============================================================================
 

--- a/src/routes/auth/status.ts
+++ b/src/routes/auth/status.ts
@@ -1,5 +1,5 @@
 import { Elysia } from 'elysia';
-import { getSetting } from '../../db/index.ts';
+import { getSetting, isDbLockError } from '../../db/index.ts';
 import {
   SESSION_COOKIE_NAME,
   isAuthenticated,
@@ -8,13 +8,27 @@ import {
 
 export const statusRoute = new Elysia().get('/status', ({ server, request, cookie }) => {
   const sessionValue = cookie[SESSION_COOKIE_NAME]?.value as string | undefined;
-  const authEnabled = getSetting('auth_enabled') === 'true';
-  const hasPassword = !!getSetting('auth_password_hash');
-  const localBypass = getSetting('auth_local_bypass') !== 'false';
-  const isLocal = isLocalNetwork(server, request);
-  const authenticated = isAuthenticated(server, request, sessionValue);
+  try {
+    const authEnabled = getSetting('auth_enabled') === 'true';
+    const hasPassword = !!getSetting('auth_password_hash');
+    const localBypass = getSetting('auth_local_bypass') !== 'false';
+    const isLocal = isLocalNetwork(server, request);
+    const authenticated = isAuthenticated(server, request, sessionValue);
 
-  return { authenticated, authEnabled, hasPassword, localBypass, isLocal };
+    return { authenticated, authEnabled, hasPassword, localBypass, isLocal };
+  } catch (err) {
+    if (isDbLockError(err)) {
+      return {
+        authenticated: false,
+        authEnabled: false,
+        hasPassword: false,
+        localBypass: true,
+        isLocal: true,
+        indexing: true,
+      };
+    }
+    throw err;
+  }
 }, {
   detail: {
     tags: ['auth'],

--- a/src/routes/dashboard/session-stats.ts
+++ b/src/routes/dashboard/session-stats.ts
@@ -1,27 +1,34 @@
 import { Elysia } from 'elysia';
 import { gt, sql } from 'drizzle-orm';
-import { db, searchLog, learnLog } from '../../db/index.ts';
+import { db, searchLog, learnLog, isDbLockError } from '../../db/index.ts';
 import { SessionStatsQuery } from './model.ts';
 
 export const sessionStatsEndpoint = new Elysia().get('/session/stats', ({ query }) => {
   const since = query.since;
   const sinceTime = since !== undefined ? parseInt(since) : Date.now() - 24 * 60 * 60 * 1000;
 
-  const searches = db.select({ count: sql<number>`count(*)` })
-    .from(searchLog)
-    .where(gt(searchLog.createdAt, sinceTime))
-    .get();
+  try {
+    const searches = db.select({ count: sql<number>`count(*)` })
+      .from(searchLog)
+      .where(gt(searchLog.createdAt, sinceTime))
+      .get();
 
-  const learnings = db.select({ count: sql<number>`count(*)` })
-    .from(learnLog)
-    .where(gt(learnLog.createdAt, sinceTime))
-    .get();
+    const learnings = db.select({ count: sql<number>`count(*)` })
+      .from(learnLog)
+      .where(gt(learnLog.createdAt, sinceTime))
+      .get();
 
-  return {
-    searches: searches?.count || 0,
-    learnings: learnings?.count || 0,
-    since: sinceTime,
-  };
+    return {
+      searches: searches?.count || 0,
+      learnings: learnings?.count || 0,
+      since: sinceTime,
+    };
+  } catch (err) {
+    if (isDbLockError(err)) {
+      return { searches: 0, learnings: 0, since: sinceTime, indexing: true };
+    }
+    throw err;
+  }
 }, {
   query: SessionStatsQuery,
   detail: {

--- a/src/routes/health/stats.ts
+++ b/src/routes/health/stats.ts
@@ -1,16 +1,23 @@
 import { Elysia } from 'elysia';
 import { DB_PATH } from '../../config.ts';
-import { getSetting } from '../../db/index.ts';
+import { getSetting, isDbLockError } from '../../db/index.ts';
 import { handleStats, handleVectorStats } from '../../server/handlers.ts';
 
 export const statsEndpoint = new Elysia().get('/stats', async () => {
-  const stats = handleStats(DB_PATH);
-  const vaultRepo = getSetting('vault_repo');
-  let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
   try {
-    vectorStats = await handleVectorStats();
-  } catch { /* vector unavailable */ }
-  return { ...stats, ...vectorStats, vault_repo: vaultRepo };
+    const stats = handleStats(DB_PATH);
+    const vaultRepo = getSetting('vault_repo');
+    let vectorStats = { vector: { enabled: false, count: 0, collection: 'oracle_knowledge' } };
+    try {
+      vectorStats = await handleVectorStats();
+    } catch { /* vector unavailable */ }
+    return { ...stats, ...vectorStats, vault_repo: vaultRepo };
+  } catch (err) {
+    if (isDbLockError(err)) {
+      return { total_docs: 0, by_type: {}, indexing: true, error: 'db temporarily unavailable' };
+    }
+    throw err;
+  }
 }, {
   detail: {
     tags: ['health'],

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import {
 
 import { PORT, ORACLE_DATA_DIR } from './config.ts';
 import { MCP_SERVER_NAME } from './const.ts';
-import { db, closeDb, indexingStatus } from './db/index.ts';
+import { db, sqlite, closeDb, indexingStatus } from './db/index.ts';
 import { seedMenuItems, type HasRoutes as SeedHasRoutes } from './db/seeders/menu-seeder.ts';
 
 // Elysia sub-apps — one per cluster
@@ -52,6 +52,11 @@ try {
 } catch (e) {
   // table might not exist yet — fine on first boot
 }
+
+try {
+  const bt = sqlite.prepare('PRAGMA busy_timeout').get();
+  console.log(`[DB] busy_timeout = ${JSON.stringify(bt)}`);
+} catch {}
 
 configure({ dataDir: ORACLE_DATA_DIR, pidFileName: 'oracle-http.pid' });
 writePidFile({
@@ -145,6 +150,16 @@ const app = new Elysia()
     set.headers['X-Frame-Options'] = 'DENY';
     set.headers['X-XSS-Protection'] = '1; mode=block';
     set.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin';
+  })
+  .onError(({ error, set }) => {
+    const msg = (error as any)?.message ?? String(error);
+    const isDbLock = msg.includes('disk I/O') || msg.includes('database is locked') || msg.includes('SQLITE_BUSY');
+    if (isDbLock) {
+      set.status = 503;
+      return { error: 'Database temporarily unavailable (indexing in progress)', indexing: true, detail: msg };
+    }
+    set.status = 500;
+    return { error: msg };
   })
   .use(
     swagger({

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -8,7 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import { eq, sql, or, inArray } from 'drizzle-orm';
-import { db, sqlite, oracleDocuments, indexingStatus } from '../db/index.ts';
+import { db, sqlite, oracleDocuments, indexingStatus, isDbLockError } from '../db/index.ts';
 import { REPO_ROOT } from '../config.ts';
 import { logSearch, logDocumentAccess, logLearning } from './logging.ts';
 import type { SearchResult, SearchResponse } from './types.ts';
@@ -291,42 +291,56 @@ function combineSearchResults(fts: SearchResult[], vector: SearchResult[]): Sear
  * Get random wisdom
  */
 export function handleReflect() {
-  // Get random document using Drizzle
-  const randomDoc = db.select({
-    id: oracleDocuments.id,
-    type: oracleDocuments.type,
-    sourceFile: oracleDocuments.sourceFile,
-    concepts: oracleDocuments.concepts
-  })
-    .from(oracleDocuments)
-    .where(or(
-      eq(oracleDocuments.type, 'principle'),
-      eq(oracleDocuments.type, 'learning')
-    ))
-    .orderBy(sql`RANDOM()`)
-    .limit(1)
-    .get();
+  try {
+    // Get random document using Drizzle
+    const randomDoc = db.select({
+      id: oracleDocuments.id,
+      type: oracleDocuments.type,
+      sourceFile: oracleDocuments.sourceFile,
+      concepts: oracleDocuments.concepts
+    })
+      .from(oracleDocuments)
+      .where(or(
+        eq(oracleDocuments.type, 'principle'),
+        eq(oracleDocuments.type, 'learning')
+      ))
+      .orderBy(sql`RANDOM()`)
+      .limit(1)
+      .get();
 
-  if (!randomDoc) {
-    return { error: 'No documents found' };
+    if (!randomDoc) {
+      return { error: 'No documents found' };
+    }
+
+    // Get content from FTS (must use raw SQL)
+    const content = sqlite.prepare(`
+      SELECT content FROM oracle_fts WHERE id = ?
+    `).get(randomDoc.id) as { content: string } | undefined;
+
+    if (!content) {
+      return { error: 'Document content not found in FTS index' };
+    }
+
+    return {
+      id: randomDoc.id,
+      type: randomDoc.type,
+      content: content.content,
+      source_file: randomDoc.sourceFile,
+      concepts: JSON.parse(randomDoc.concepts || '[]')
+    };
+  } catch (err) {
+    if (isDbLockError(err)) {
+      return {
+        id: null,
+        type: 'principle',
+        content: 'Oracle is indexing — please wait...',
+        source_file: null,
+        concepts: [],
+        indexing: true,
+      };
+    }
+    throw err;
   }
-
-  // Get content from FTS (must use raw SQL)
-  const content = sqlite.prepare(`
-    SELECT content FROM oracle_fts WHERE id = ?
-  `).get(randomDoc.id) as { content: string } | undefined;
-
-  if (!content) {
-    return { error: 'Document content not found in FTS index' };
-  }
-
-  return {
-    id: randomDoc.id,
-    type: randomDoc.type,
-    content: content.content,
-    source_file: randomDoc.sourceFile,
-    concepts: JSON.parse(randomDoc.concepts || '[]')
-  };
 }
 
 /**


### PR DESCRIPTION
Global .onError() + per-endpoint try/catch fallbacks. Returns JSON with indexing:true instead of 500 text. Closes #1067.